### PR TITLE
[Feat/BE/#47] 학생 대학교 이메일 저장 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
     // H2
     implementation 'com.h2database:h2'
     // Mongodb

--- a/backend/src/main/java/com/bungeobbang/backend/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/bungeobbang/backend/common/exception/ErrorCode.java
@@ -5,6 +5,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+    // Member
+    INVALID_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    // University
+    INVALID_UNIVERSITY(HttpStatus.NOT_FOUND, "아직 등록되지 않은 대학교입니다."),
     // Auth
     INVALID_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
     NOT_SUPPORTED_OAUTH_SERVICE(HttpStatus.NOT_IMPLEMENTED, "해당 OAuth 서비스는 제공하지 않습니다."),
@@ -13,6 +17,7 @@ public enum ErrorCode {
     TEMPLATE_FILE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿을 읽는 도중 오류가 발생하였습니다."),
     CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다"),
     EMAIL_CODE_EXPIRED(HttpStatus.GONE, "이메일 인증 코드가 만료되었습니다."),
+    UNIVERSITY_DOMAIN_MISMATCH(HttpStatus.BAD_REQUEST, "대학교 이메일과 도메인이 일치하지 않습니다."),
     INVALID_ADMIN(HttpStatus.BAD_REQUEST, "존재하지 않는 관리자입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 

--- a/backend/src/main/java/com/bungeobbang/backend/common/exception/MemberException.java
+++ b/backend/src/main/java/com/bungeobbang/backend/common/exception/MemberException.java
@@ -1,0 +1,8 @@
+package com.bungeobbang.backend.common.exception;
+
+public class MemberException extends DomainException {
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/bungeobbang/backend/common/exception/UniversityException.java
+++ b/backend/src/main/java/com/bungeobbang/backend/common/exception/UniversityException.java
@@ -1,0 +1,8 @@
+package com.bungeobbang.backend.common.exception;
+
+public class UniversityException extends DomainException {
+
+    public UniversityException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/bungeobbang/backend/member/domain/Member.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/domain/Member.java
@@ -38,6 +38,11 @@ public class Member extends BaseTimeEntity {
         this.provider = provider;
     }
 
+    public void updateUniversity(University university, String email) {
+        this.university = university;
+        this.email = email;
+    }
+
     @Override
     public String toString() {
         return String.format("id = %s, loginId = %s, email = %s, provider = %s", id, loginId, email, provider);

--- a/backend/src/main/java/com/bungeobbang/backend/member/dto/request/MemberUniversityUpdateRequest.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/dto/request/MemberUniversityUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.bungeobbang.backend.member.dto.request;
+
+public record MemberUniversityUpdateRequest(
+        Long memberId,
+        Long universityId,
+        String email
+) {
+}

--- a/backend/src/main/java/com/bungeobbang/backend/member/dto/request/SocialLoginRequest.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/dto/request/SocialLoginRequest.java
@@ -1,0 +1,6 @@
+package com.bungeobbang.backend.member.dto.request;
+
+public record SocialLoginRequest(
+        String code
+) {
+}

--- a/backend/src/main/java/com/bungeobbang/backend/member/dto/response/MemberLoginResponse.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/dto/response/MemberLoginResponse.java
@@ -1,4 +1,6 @@
 package com.bungeobbang.backend.member.dto.response;
 
-public record MemberLoginResponse(Long memberId, String refreshToken) {
+public record MemberLoginResponse(
+        Long memberId,
+        boolean isEmailVerified) {
 }

--- a/backend/src/main/java/com/bungeobbang/backend/member/dto/response/MemberLoginResult.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/dto/response/MemberLoginResult.java
@@ -1,4 +1,8 @@
 package com.bungeobbang.backend.member.dto.response;
 
-public record MemberLoginResult(Long memberId, String accessToken, String refreshToken) {
+public record MemberLoginResult(
+        Long memberId,
+        boolean isEmailVerified,
+        String accessToken,
+        String refreshToken) {
 }

--- a/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
@@ -1,14 +1,15 @@
 package com.bungeobbang.backend.member.presentation;
 
 import com.bungeobbang.backend.member.domain.ProviderType;
+import com.bungeobbang.backend.member.dto.request.SocialLoginRequest;
 import com.bungeobbang.backend.member.dto.response.MemberLoginResponse;
 import com.bungeobbang.backend.member.dto.response.MemberLoginResult;
 import com.bungeobbang.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,13 +18,13 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @GetMapping("/student/auth/{provider}/login")
+    @PostMapping("/student/auth/{provider}/login")
     public ResponseEntity<MemberLoginResponse> login(
             @PathVariable final String provider,
-            @RequestParam final String code
-            ) {
+            @RequestBody final SocialLoginRequest request
+    ) {
         final ProviderType providerType = ProviderType.fromString(provider);
-        final MemberLoginResult memberLoginResult = memberService.login(providerType, code);
+        final MemberLoginResult memberLoginResult = memberService.login(providerType, request.code());
         return ResponseEntity.ok()
                 .header("Authorization", String.format("Bearer %s", memberLoginResult.accessToken()))
                 .body(new MemberLoginResponse(memberLoginResult.memberId(), memberLoginResult.refreshToken()));

--- a/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/student/auth")
 @RequiredArgsConstructor
 public class MemberController {
-
+    private final static String ACCESS_TOKEN = "access-token";
+    private final static String REFRESH_TOKEN = "refresh-token";
     private final MemberService memberService;
 
     @PostMapping("/{provider}/login")
@@ -25,8 +26,9 @@ public class MemberController {
         final ProviderType providerType = ProviderType.fromString(provider);
         final MemberLoginResult memberLoginResult = memberService.login(providerType, request.code());
         return ResponseEntity.ok()
-                .header("Authorization", String.format("Bearer %s", memberLoginResult.accessToken()))
-                .body(new MemberLoginResponse(memberLoginResult.memberId(), memberLoginResult.refreshToken()));
+                .header(ACCESS_TOKEN, memberLoginResult.accessToken())
+                .header(REFRESH_TOKEN, memberLoginResult.refreshToken())
+                .body(new MemberLoginResponse(memberLoginResult.memberId(), memberLoginResult.isEmailVerified()));
     }
 
     @PatchMapping("/university")

--- a/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/presentation/MemberController.java
@@ -1,24 +1,23 @@
 package com.bungeobbang.backend.member.presentation;
 
 import com.bungeobbang.backend.member.domain.ProviderType;
+import com.bungeobbang.backend.member.dto.request.MemberUniversityUpdateRequest;
 import com.bungeobbang.backend.member.dto.request.SocialLoginRequest;
 import com.bungeobbang.backend.member.dto.response.MemberLoginResponse;
 import com.bungeobbang.backend.member.dto.response.MemberLoginResult;
 import com.bungeobbang.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/student/auth")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/student/auth/{provider}/login")
+    @PostMapping("/{provider}/login")
     public ResponseEntity<MemberLoginResponse> login(
             @PathVariable final String provider,
             @RequestBody final SocialLoginRequest request
@@ -28,5 +27,11 @@ public class MemberController {
         return ResponseEntity.ok()
                 .header("Authorization", String.format("Bearer %s", memberLoginResult.accessToken()))
                 .body(new MemberLoginResponse(memberLoginResult.memberId(), memberLoginResult.refreshToken()));
+    }
+
+    @PatchMapping("/university")
+    public ResponseEntity<Void> updateUniversity(@RequestBody final MemberUniversityUpdateRequest request) {
+        memberService.updateUniversityInfo(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
@@ -58,7 +58,10 @@ public class MemberService {
     private MemberLoginResult getLoginResultResponse(final Member member) {
         final MemberTokens memberTokens = jwtProvider.generateLoginToken(member.getId().toString());
         saveRefreshToken(member, memberTokens.refreshToken());
-        return new MemberLoginResult(member.getId(), memberTokens.accessToken(), memberTokens.refreshToken());
+        return new MemberLoginResult(member.getId(),
+                member.getUniversity() != null,
+                memberTokens.accessToken(),
+                memberTokens.refreshToken());
     }
 
     private void saveRefreshToken(final Member member, final String refreshToken) {

--- a/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
@@ -1,18 +1,25 @@
 package com.bungeobbang.backend.member.service;
 
+import com.bungeobbang.backend.common.exception.AuthException;
 import com.bungeobbang.backend.common.infrastructure.JwtProvider;
 import com.bungeobbang.backend.common.infrastructure.RedisClient;
 import com.bungeobbang.backend.member.domain.Member;
 import com.bungeobbang.backend.member.domain.ProviderType;
 import com.bungeobbang.backend.member.domain.repository.MemberRepository;
+import com.bungeobbang.backend.member.dto.request.MemberUniversityUpdateRequest;
 import com.bungeobbang.backend.member.dto.response.MemberLoginResult;
 import com.bungeobbang.backend.member.dto.response.MemberTokens;
 import com.bungeobbang.backend.member.infrastructure.oauthprovider.OauthProvider;
 import com.bungeobbang.backend.member.infrastructure.oauthprovider.OauthProviders;
 import com.bungeobbang.backend.member.infrastructure.oauthuserinfo.OauthUserInfo;
+import com.bungeobbang.backend.university.domain.University;
+import com.bungeobbang.backend.university.domain.repository.UniversityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.bungeobbang.backend.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ public class MemberService {
 
     private final OauthProviders oauthProviders;
     private final MemberRepository memberRepository;
+    private final UniversityRepository universityRepository;
     private final JwtProvider jwtProvider;
     private final RedisClient redisClient;
 
@@ -31,6 +39,20 @@ public class MemberService {
         final Member member = findOrCreateMember(oauthUserInfo.getSocialLoginId(), providerType);
         log.info("member: {}", member);
         return getLoginResultResponse(member);
+    }
+
+    @Transactional
+    public void updateUniversityInfo(final MemberUniversityUpdateRequest request) {
+        final Member member = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new AuthException(INVALID_MEMBER));
+        final University university = universityRepository.findById(request.universityId())
+                .orElseThrow(() -> new AuthException(INVALID_UNIVERSITY));
+
+        if (!request.email().split("@")[1].equals(university.getDomain())) {
+            throw new AuthException(UNIVERSITY_DOMAIN_MISMATCH);
+        }
+
+        member.updateUniversity(university, request.email());
     }
 
     private MemberLoginResult getLoginResultResponse(final Member member) {

--- a/backend/src/main/java/com/bungeobbang/backend/university/domain/University.java
+++ b/backend/src/main/java/com/bungeobbang/backend/university/domain/University.java
@@ -24,4 +24,9 @@ public class University extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String domain;
+
+    public University(String name, String domain) {
+        this.name = name;
+        this.domain = domain;
+    }
 }

--- a/backend/src/test/java/com/bungeobbang/backend/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/member/service/MemberServiceTest.java
@@ -1,0 +1,100 @@
+package com.bungeobbang.backend.member.service;
+
+import com.bungeobbang.backend.common.exception.AuthException;
+import com.bungeobbang.backend.common.infrastructure.JwtProvider;
+import com.bungeobbang.backend.common.infrastructure.RedisClient;
+import com.bungeobbang.backend.member.domain.Member;
+import com.bungeobbang.backend.member.domain.repository.MemberRepository;
+import com.bungeobbang.backend.member.dto.request.MemberUniversityUpdateRequest;
+import com.bungeobbang.backend.university.domain.University;
+import com.bungeobbang.backend.university.domain.repository.UniversityRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.bungeobbang.backend.common.exception.ErrorCode.*;
+import static com.bungeobbang.backend.member.domain.ProviderType.KAKAO;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private UniversityRepository universityRepository;
+    @Mock
+    private RedisClient redisClient;
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("데이터베이스에 저장되지 않은 사용자가 대학교 정보를 변경하면 에러가 발생한다.")
+    void updateUniversityInfo_invalidMember() {
+        // given
+        when(memberRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.empty());
+        MemberUniversityUpdateRequest request = new MemberUniversityUpdateRequest(1L, 1L, "test@test.ac.kr");
+        // when & then
+        assertThatThrownBy(() -> memberService.updateUniversityInfo(request))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_MEMBER.getMessage());
+    }
+
+    @Test
+    @DisplayName("아직 등록되지 않은 대학교로 대학교 정보를 변경하면 에러가 발생한다.")
+    void updateUniversityInfo_invalidUniversity() {
+        // given
+        Member member = new Member("loginId", KAKAO);
+        MemberUniversityUpdateRequest request = new MemberUniversityUpdateRequest(1L, 1L, "test@test.ac.kr");
+        when(memberRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.of(member));
+        when(universityRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateUniversityInfo(request))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(INVALID_UNIVERSITY.getMessage());
+    }
+
+    @Test
+    @DisplayName("사용자가 대학 정보를 변경한다.")
+    void updateUniversityInfo_validMember() {
+        // given
+        Member member = new Member("loginId", KAKAO);
+        MemberUniversityUpdateRequest request = new MemberUniversityUpdateRequest(1L, 1L, "test@test.ac.kr");
+        when(memberRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.of(member));
+        when(universityRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.of(new University("테스트 대학교", "test.ac.kr")));
+
+        memberService.updateUniversityInfo(request);
+    }
+
+    @Test
+    @DisplayName("이메일이 대학 도메인과 일치하지 않으면 에러가 발생한다.")
+    void updateUniversityInfo_domainMismatch() {
+        // given
+        Member member = new Member("loginId", KAKAO);
+        MemberUniversityUpdateRequest request = new MemberUniversityUpdateRequest(1L, 1L, "test@mismatch.ac.kr");
+        when(memberRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.of(member));
+        when(universityRepository.findById(Mockito.anyLong()))
+                .thenReturn(Optional.of(new University("테스트 대학교", "test.ac.kr")));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateUniversityInfo(request))
+                .isInstanceOf(AuthException.class)
+                .hasMessage(UNIVERSITY_DOMAIN_MISMATCH.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 대학교 저장 api
- 테스트 코드 작성


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 이메일 인증 후 대학교를 저장하는 API를 구현하였습니다.
- swagger 사용을 위한 의존성 추가하였습니다.


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 소셜 로그인 get -> post
    - API문서에 따라 변경하였습니다.
- url 공통되는 부분 @RequestMapping 으로 묶어주었습니다.


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #47 
- Closes #40
- 관련 링크: 

![Uploading 스크린샷 2025-01-30 오후 8.17.04.png…]()

---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 학생 로그인 기능에서 빠진 부분 없는지 확인 부탁드립니다.