### PR TITLE
[FEAT/FE/#5] 로그인 로직 구현 완료

### DIFF
--- a/frontend/src/domains/student/App.tsx
+++ b/frontend/src/domains/student/App.tsx
@@ -9,7 +9,7 @@ function StudentApp() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<LoginPage />} />
-        <Route path="/oauth/callback/kakao" element={<OAuthCallback />} />
+        <Route path="/kakao/redirect" element={<OAuthCallback />} />
         <Route path="/google/redirect" element={<OAuthCallback />} />
         <Route path="/email" element={<EmailVerification />} />
         <Route path="/univ" element={<UniversitySelection />} />

--- a/frontend/src/domains/student/pages/login/emailcheck/auth.ts
+++ b/frontend/src/domains/student/pages/login/emailcheck/auth.ts
@@ -30,9 +30,10 @@ export const confirmEmailVerification = async (
 ): Promise<EmailResponse> => {
   try {
     const requestBody: EmailVerificationRequest = { email: email, code: code };
-    const response = await api.post('/api/auth/email/confirm', requestBody);
-    return response.data;
+    const response = await api.post('/student/auth/email/verify', requestBody);
+    return response.status;
   } catch (error) {
+    console.log(error);
     throw new Error(error.response?.data?.message || '인증 코드 확인에 실패하였습니다.');
   }
 };

--- a/frontend/src/domains/student/pages/login/emailcheck/auth.ts
+++ b/frontend/src/domains/student/pages/login/emailcheck/auth.ts
@@ -33,7 +33,6 @@ export const confirmEmailVerification = async (
     const response = await api.post('/student/auth/email/verify', requestBody);
     return response.status;
   } catch (error) {
-    console.log(error);
     throw new Error(error.response?.data?.message || '인증 코드 확인에 실패하였습니다.');
   }
 };

--- a/frontend/src/domains/student/pages/login/emailcheck/index.tsx
+++ b/frontend/src/domains/student/pages/login/emailcheck/index.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { ChevronLeft } from 'react-feather';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { sendEmailVerification, confirmEmailVerification } from './auth';
 import * as S from './styles';
+import api from '@/utils/api';
+import JWTManager from '@/utils/jwtManager';
 
 type Step = 'email' | 'verification';
 
@@ -14,16 +16,14 @@ export default function SchoolEmailPage() {
   const [error, setError] = useState<string | null>(null);
 
   const navigate = useNavigate();
+  const location = useLocation();
+  const university = location.state?.university;
 
   const isEmailValid = email.length > 0;
   const isVerificationValid = verificationCode.length > 0;
 
   const handleGoBack = () => {
-    if (step === 'verification') {
-      setStep('email');
-    } else {
-      navigate(-1);
-    }
+    step === 'verification' ? setStep('email') : navigate(-1);
   };
 
   const handleSubmitEmail = async () => {
@@ -33,9 +33,7 @@ export default function SchoolEmailPage() {
     setError(null);
 
     try {
-      const jo = await sendEmailVerification(email);
-      console.log(jo);
-
+      await sendEmailVerification(email);
       setStep('verification');
     } catch (err) {
       setError(err instanceof Error ? err.message : '인증 코드 전송에 실패하였습니다.');
@@ -50,13 +48,41 @@ export default function SchoolEmailPage() {
     setError(null);
 
     try {
-      await confirmEmailVerification(email, verificationCode);
-      // 인증 성공 후 처리
+      const isConfirmed = await confirmEmailVerification(email, verificationCode);
+      console.log(isConfirmed);
+      Number(isConfirmed) === 200
+        ? await patchUniversity(email)
+        : setError('인증 코드 확인에 실패하였습니다.');
+
       console.log('인증 성공');
     } catch (err) {
       setError(err instanceof Error ? err.message : '인증 코드 확인에 실패하였습니다.');
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const patchUniversity = async (email: string) => {
+    if (!university) {
+      return;
+    }
+
+    const memberId = await JWTManager.getMemberId();
+
+    try {
+      await api.patch('/student/auth/university', {
+        memberId: memberId,
+        universityId: university.id,
+        email: email,
+      });
+
+      // navigate('/main');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : '학교 정보 저장에 실패하였습니다. <br /> 다시 시도해주세요.',
+      );
     }
   };
 

--- a/frontend/src/domains/student/pages/login/emailcheck/index.tsx
+++ b/frontend/src/domains/student/pages/login/emailcheck/index.tsx
@@ -49,12 +49,10 @@ export default function SchoolEmailPage() {
 
     try {
       const isConfirmed = await confirmEmailVerification(email, verificationCode);
-      console.log(isConfirmed);
+
       Number(isConfirmed) === 200
         ? await patchUniversity(email)
         : setError('인증 코드 확인에 실패하였습니다.');
-
-      console.log('인증 성공');
     } catch (err) {
       setError(err instanceof Error ? err.message : '인증 코드 확인에 실패하였습니다.');
     } finally {

--- a/frontend/src/domains/student/pages/login/index.tsx
+++ b/frontend/src/domains/student/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+// import React from 'react';
 import * as S from './styles';
 import { AUTH_CONFIG } from '../../../../config/auth';
 import logoImage from '@/assets/icons/logo.png';

--- a/frontend/src/domains/student/pages/login/univcheck/index.tsx
+++ b/frontend/src/domains/student/pages/login/univcheck/index.tsx
@@ -1,24 +1,49 @@
-import { React, useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ChevronLeft } from 'react-feather';
 import { useNavigate } from 'react-router-dom';
 import * as S from './styles';
+import api from '@/utils/api';
 
-const universities = ['서울대학교', '연세대학교', '고려대학교', '성균관대학교', '한양대학교'];
-
-const UniversitySelection: React.FC = () => {
+interface University {
+  id: number;
+  name: string;
+  domain: string;
+}
+const UniversitySelection = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedUniversity, setSelectedUniversity] = useState<string>('');
+  const [selectedUniversity, setSelectedUniversity] = useState<University | null>(null);
+  const [universityObject, setUniversityObject] = useState<University[]>([]);
   const navigate = useNavigate();
 
-  const handleUniversitySelect = (university: string) => {
+  useEffect(() => {
+    const FetchUniversities = async () => {
+      try {
+        const response = await api.get('/api/universities');
+        setUniversityObject(response.data);
+      } catch (error) {
+        alert(
+          (error as { response?: { data: { message: string } } }).response?.data.message ||
+            '대학교 정보를 불러오는데 실패했습니다. 다시 시도해주세요.',
+        );
+        navigate(-1);
+      }
+    };
+
+    FetchUniversities();
+  }, [navigate]);
+
+  const handleUniversitySelect = (university: University) => {
     setSelectedUniversity(university);
     setIsOpen(false);
   };
 
   const handleNext = () => {
     if (selectedUniversity) {
-      // 대학 등록 로직 구현
-      navigate('/email');
+      navigate('/email', {
+        state: {
+          university: selectedUniversity,
+        },
+      });
     }
   };
 
@@ -31,18 +56,21 @@ const UniversitySelection: React.FC = () => {
       <S.Subtitle>제휴를 맺은 학교의 재학생만 가입할 수 있어요.</S.Subtitle>
 
       <S.SelectButton onClick={() => setIsOpen(true)}>
-        {selectedUniversity || '대학교 선택'}
+        {selectedUniversity?.name || '대학교 선택'}
       </S.SelectButton>
 
-      <S.BottomSheet $isOpen={isOpen}>
+      <S.BottomSheet isOpen={isOpen}>
         <S.BottomSheetHeader>
           <S.BottomSheetTitle>대학교 선택</S.BottomSheetTitle>
           <S.CloseButton onClick={() => setIsOpen(false)}>×</S.CloseButton>
         </S.BottomSheetHeader>
         <S.UniversityList>
-          {universities.map((university) => (
-            <S.UniversityItem key={university} onClick={() => handleUniversitySelect(university)}>
-              {university}
+          {universityObject.map((university) => (
+            <S.UniversityItem
+              key={university.id}
+              onClick={() => handleUniversitySelect(university)}
+            >
+              {university.name}
             </S.UniversityItem>
           ))}
         </S.UniversityList>
@@ -54,5 +82,4 @@ const UniversitySelection: React.FC = () => {
     </S.Container>
   );
 };
-
 export default UniversitySelection;

--- a/frontend/src/domains/student/pages/oauth/callback/index.tsx
+++ b/frontend/src/domains/student/pages/oauth/callback/index.tsx
@@ -17,17 +17,19 @@ const OAuthCallback = () => {
       }
 
       try {
-        const code = decodeURIComponent(encodedCode);
-
-        const { data } = await api.post(`/student/auth/${provider}/login`, {
-          code,
+        const response = await api.post(`/student/auth/${provider}/login`, {
+          code: decodeURIComponent(encodedCode),
         });
+        const accessToken = response.headers['access-token'];
+        const refreshToken = response.headers['refresh-token'];
+        const memberID = response.data.memberId;
 
-        console.log(data);
+        if (!accessToken || !refreshToken || !memberID) {
+          throw new Error(' token or member id not found in headers');
+        }
 
-        await JWTManager.setTokens(data);
-        //if (data.isNew) navigate('/home');
-        //else
+        await JWTManager.setTokens(refreshToken, accessToken, memberID);
+        reponse.data.isEmailVerified ? navigate('/main') : navigate('/email');
         navigate('/univ');
       } catch (error) {
         console.error('Login failed:', error);

--- a/frontend/src/domains/student/pages/oauth/callback/index.tsx
+++ b/frontend/src/domains/student/pages/oauth/callback/index.tsx
@@ -20,6 +20,7 @@ const OAuthCallback = () => {
         const response = await api.post(`/student/auth/${provider}/login`, {
           code: decodeURIComponent(encodedCode),
         });
+        console.log(response);
         const accessToken = response.headers['access-token'];
         const refreshToken = response.headers['refresh-token'];
         const memberID = response.data.memberId;
@@ -29,7 +30,7 @@ const OAuthCallback = () => {
         }
 
         await JWTManager.setTokens(refreshToken, accessToken, memberID);
-        reponse.data.isEmailVerified ? navigate('/main') : navigate('/email');
+        response.data.isEmailVerified ? navigate('/main') : navigate('/email');
         navigate('/univ');
       } catch (error) {
         console.error('Login failed:', error);

--- a/frontend/src/domains/student/pages/oauth/callback/index.tsx
+++ b/frontend/src/domains/student/pages/oauth/callback/index.tsx
@@ -20,7 +20,7 @@ const OAuthCallback = () => {
         const response = await api.post(`/student/auth/${provider}/login`, {
           code: decodeURIComponent(encodedCode),
         });
-        console.log(response);
+
         const accessToken = response.headers['access-token'];
         const refreshToken = response.headers['refresh-token'];
         const memberID = response.data.memberId;
@@ -33,7 +33,7 @@ const OAuthCallback = () => {
         response.data.isEmailVerified ? navigate('/main') : navigate('/email');
         navigate('/univ');
       } catch (error) {
-        console.error('Login failed:', error);
+        console.error('OAuth callback error:', error);
         navigate('/');
       }
     };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+// import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@/styles/fonts.css';
 import '@/styles/reset.css';
@@ -7,6 +7,4 @@ import AdminApp from './domains/admin/App.tsx';
 
 const isAdmin = window.location.pathname.startsWith('/admin');
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>{isAdmin ? <AdminApp /> : <StudentApp />}</StrictMode>,
-);
+createRoot(document.getElementById('root')!).render(isAdmin ? <AdminApp /> : <StudentApp />);

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -40,6 +40,8 @@ api.interceptors.response.use(
           return api(originalRequest);
         }
       } catch (refreshError) {
+        console.log('Refresh token error:', refreshError);
+
         await JWTManager.clearTokens();
       }
     }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -11,11 +11,15 @@ const api: AxiosInstance = axios.create({
 // 요청 인터셉터
 api.interceptors.request.use(
   async (config) => {
-    const token = await JWTManager.getAccessToken();
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    try {
+      const token = await JWTManager.getAccessToken();
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    } catch (error) {
+      return Promise.reject(error);
     }
-    return config;
   },
   (error) => Promise.reject(error),
 );
@@ -30,26 +34,13 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refreshToken = await JWTManager.getRefreshToken();
-        const { data } = await axios.post(
-          `${AUTH_CONFIG.API.BASE_URL}/auth/refresh`,
-          { refresh: refreshToken },
-          { withCredentials: true },
-        );
-
-        await JWTManager.setTokens({
-          access: data.accessToken,
-          refresh: refreshToken as string,
-        });
-
-        if (originalRequest.headers) {
-          originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+        const token = await JWTManager.getAccessToken(); // 자동으로 refresh 처리
+        if (token && originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${token}`;
+          return api(originalRequest);
         }
-
-        return api(originalRequest);
       } catch (refreshError) {
         await JWTManager.clearTokens();
-        return Promise.reject(refreshError);
       }
     }
 

--- a/frontend/src/utils/jwtManager.ts
+++ b/frontend/src/utils/jwtManager.ts
@@ -1,10 +1,16 @@
 class JWTManager {
   private static instance: JWTManager;
   private accessToken: string | null = null;
-  private refreshToken: string | null = null;
   private memberId: number | null = null;
+  private readonly REFRESH_TOKEN_KEY = 'refresh-token';
 
-  private constructor() {}
+  private constructor() {
+    // 초기화 시 localStorage에서 refresh token 복원
+    const savedRefreshToken = localStorage.getItem(this.REFRESH_TOKEN_KEY);
+    if (savedRefreshToken) {
+      this.refreshAccessToken(savedRefreshToken);
+    }
+  }
 
   public static getInstance(): JWTManager {
     if (!JWTManager.instance) {
@@ -15,26 +21,48 @@ class JWTManager {
 
   async setTokens(refreshToken: string, accessToken: string, memberID: number): Promise<void> {
     this.accessToken = accessToken;
-    this.refreshToken = refreshToken;
     this.memberId = memberID;
+    // refresh token을 localStorage에 저장
+    localStorage.setItem(this.REFRESH_TOKEN_KEY, refreshToken);
   }
 
   async getAccessToken(): Promise<string | null> {
+    if (!this.accessToken) {
+      // access token이 없으면 refresh token으로 재발급 시도
+      const refreshToken = localStorage.getItem(this.REFRESH_TOKEN_KEY);
+      if (refreshToken) {
+        await this.refreshAccessToken(refreshToken);
+      }
+    }
     return this.accessToken;
   }
 
   async getRefreshToken(): Promise<string | null> {
-    return this.refreshToken;
+    return localStorage.getItem(this.REFRESH_TOKEN_KEY);
   }
 
   async getMemberId(): Promise<number | null> {
     return this.memberId;
   }
 
+  private async refreshAccessToken(refreshToken: string): Promise<void> {
+    try {
+      const { data } = await axios.post(
+        `${AUTH_CONFIG.API.BASE_URL}/auth/refresh`,
+        { refresh: refreshToken },
+        { withCredentials: true },
+      );
+      this.accessToken = data.accessToken;
+    } catch (error) {
+      await this.clearTokens();
+      throw error;
+    }
+  }
+
   async clearTokens(): Promise<void> {
     this.accessToken = null;
-    this.refreshToken = null;
     this.memberId = null;
+    localStorage.removeItem(this.REFRESH_TOKEN_KEY);
     window.location.href = '/';
   }
 }

--- a/frontend/src/utils/jwtManager.ts
+++ b/frontend/src/utils/jwtManager.ts
@@ -1,12 +1,8 @@
-interface Tokens {
-  access: string;
-  refresh: string;
-}
-
 class JWTManager {
   private static instance: JWTManager;
   private accessToken: string | null = null;
   private refreshToken: string | null = null;
+  private memberId: number | null = null;
 
   private constructor() {}
 
@@ -17,9 +13,10 @@ class JWTManager {
     return JWTManager.instance;
   }
 
-  async setTokens({ access, refresh }: Tokens): Promise<void> {
-    this.accessToken = access;
-    this.refreshToken = refresh;
+  async setTokens(refreshToken: string, accessToken: string, memberID: number): Promise<void> {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.memberId = memberID;
   }
 
   async getAccessToken(): Promise<string | null> {
@@ -30,9 +27,14 @@ class JWTManager {
     return this.refreshToken;
   }
 
+  async getMemberId(): Promise<number | null> {
+    return this.memberId;
+  }
+
   async clearTokens(): Promise<void> {
     this.accessToken = null;
     this.refreshToken = null;
+    this.memberId = null;
     window.location.href = '/';
   }
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -6,6 +6,10 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## 📌 작업 내용

- 로그인 로직을 구현 및 서버와의 연동 완료
- refresh 토큰 저장 방식 변경
---

## 📂 주요 변경사항

- refresh 토큰 local storage 에 저장 및 , 자동 token 갱신 로직 변경
- 각 상황별 에러처리 구현



---

## 📑 세부 변경사항

- react router dom 의 useLocation 을 이용해서 학교 id 를 이메일 인증 화면에 넘겨서 사용
- data fetching 중 에러 발생시 토큰 관련 문제일 경우 로그인화면으로, 이외 문제일경우 이전 화면으로 리다이렉팅

---

## 🔗 관련 이슈

- Closes #6
- Closes #17 
- Closes #19 
- Closes #21 
- Closes #22
- Closes #23 
- Closes #25

---

## ✅ 검토 요청사항

- [ ] api 및 JWT 관련 로직
