### PR TITLE
[Feat/Be/#94] 답해요 채팅방 조회 API

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // query dsl
-    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    implementation 'com.querydsl:querydsl-jpa:5.1.1:jakarta'
     implementation group: 'com.querydsl', name: 'querydsl-core', version: '5.1.0'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,6 +47,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // query dsl
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    implementation group: 'com.querydsl', name: 'querydsl-core', version: '5.1.0'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -55,3 +61,11 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+def querydslSrcDir = 'src/main/generated'
+clean {
+    delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // query dsl
-    implementation 'com.querydsl:querydsl-jpa:5.1.1:jakarta'
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     implementation group: 'com.querydsl', name: 'querydsl-core', version: '5.1.0'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/infrastructure/CustomAgendaRepositoryImpl.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/infrastructure/CustomAgendaRepositoryImpl.java
@@ -1,0 +1,149 @@
+package com.bungeobbang.backend.agenda.domain.infrastructure;
+
+import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaRepository;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.bungeobbang.backend.agenda.domain.QAgenda.agenda;
+
+/**
+ * <h2>CustomAgendaRepositoryImpl</h2>
+ * <p>QueryDSL을 이용한 커스텀 답해요(Ageanda) 조회 Repository 구현체</p>
+ * <p>안건 목록을 상태별(예정, 진행 중, 종료됨)로 조회하며, 무한 스크롤을 지원합니다.</p>
+ *
+ * @author [zoouniak]
+ * @version 1.0
+ */
+@Repository
+@RequiredArgsConstructor
+public class CustomAgendaRepositoryImpl implements CustomAgendaRepository {
+    private final JPAQueryFactory queryFactory;
+    private final int AGENDA_SIZE = 8; // 페이지당 조회할 답해요 개수
+
+    /**
+     * <h3>예정된 안건 목록 조회</h3>
+     * <p>현재 날짜 기준으로 아직 시작되지 않은 안건 목록을 조회합니다.</p>
+     *
+     * @param universityId 대학교 ID (필수)
+     * @param endDate      마지막으로 조회된 안건의 종료 날짜 (무한 스크롤을 위한 커서)
+     * @param agendaId     마지막으로 조회된 안건의 ID (중복 방지 및 페이징용)
+     * @return 예정된 안건 목록 (최대 8개)
+     */
+    @Override
+    public List<AgendaResponse> getUpcomingAgendas(Long universityId, LocalDate endDate, Long agendaId) {
+        return queryFactory.select(Projections.constructor(AgendaResponse.class,
+                        agenda.id,
+                        agenda.categoryType,
+                        agenda.title,
+                        agenda.startDate,
+                        agenda.endDate,
+                        agenda.count))
+                .from(agenda)
+                .where(
+                        agenda.university.id.eq(universityId)
+                                .and(agenda.startDate.gt(LocalDate.now())) // 시작 전 상태
+                                .and(gtEndDateOrEqEndDateAndGtId(endDate, agendaId)) // 무한 스크롤
+                )
+                .orderBy(agenda.endDate.asc(), agenda.id.asc()) // 종료 날짜 오름차순 정렬
+                .limit(AGENDA_SIZE) // 페이지 사이즈 제한
+                .fetch();
+    }
+
+    /**
+     * <h3>진행 중인 안건 목록 조회</h3>
+     * <p>현재 날짜 기준으로 진행 중(시작됨~종료 전)인 안건 목록을 조회합니다.</p>
+     *
+     * @param universityId 대학교 ID (필수)
+     * @param endDate      마지막으로 조회된 안건의 종료 날짜 (무한 스크롤을 위한 커서)
+     * @param agendaId     마지막으로 조회된 안건의 ID (중복 방지 및 페이징용)
+     * @return 진행 중인 안건 목록 (최대 8개)
+     */
+    @Override
+    public List<AgendaResponse> getActiveAgendas(Long universityId, LocalDate endDate, Long agendaId) {
+        return queryFactory.select(Projections.constructor(AgendaResponse.class,
+                        agenda.id.as("agendaId"),
+                        agenda.categoryType,
+                        agenda.title,
+                        agenda.startDate,
+                        agenda.endDate,
+                        agenda.count
+                ))
+                .from(agenda)
+                .where(
+                        agenda.university.id.eq(universityId)
+                                .and(agenda.startDate.lt(LocalDate.now())) // 이미 시작됨
+                                .and(agenda.endDate.gt(LocalDate.now())) // 아직 종료되지 않음
+                                .and(gtEndDateOrEqEndDateAndGtId(endDate, agendaId)) // 무한 스크롤
+                )
+                .orderBy(agenda.endDate.asc(), agenda.id.asc()) // 종료 날짜 오름차순 정렬
+                .limit(AGENDA_SIZE) // 페이지 사이즈 제한
+                .fetch();
+    }
+
+    /**
+     * <h3>종료된 안건 목록 조회</h3>
+     * <p>현재 날짜 기준으로 이미 종료된 안건 목록을 조회합니다.</p>
+     *
+     * @param universityId 대학교 ID (필수)
+     * @param endDate      마지막으로 조회된 안건의 종료 날짜 (무한 스크롤을 위한 커서)
+     * @param agendaId     마지막으로 조회된 안건의 ID (중복 방지 및 페이징용)
+     * @return 종료된 안건 목록 (최대 8개)
+     */
+    @Override
+    public List<AgendaResponse> getClosedAgendas(Long universityId, LocalDate endDate, Long agendaId) {
+        return queryFactory.select(Projections.constructor(AgendaResponse.class,
+                        agenda.id.as("agendaId"),
+                        agenda.categoryType,
+                        agenda.title,
+                        agenda.startDate,
+                        agenda.endDate,
+                        agenda.count
+                ))
+                .from(agenda)
+                .where(
+                        agenda.university.id.eq(universityId)
+                                .and(agenda.endDate.lt(LocalDate.now())) // 종료된 상태
+                                .and(ltEndDateOrEqEndDateAndGtId(endDate, agendaId)) // 무한 스크롤
+                )
+                .orderBy(agenda.endDate.desc(), agenda.id.asc()) // 종료 날짜 내림차순 정렬
+                .limit(AGENDA_SIZE) // 페이지 사이즈 제한
+                .fetch();
+    }
+
+    /**
+     * <h3>커서 기반 무한 스크롤 지원 - 종료 날짜 기준 조회</h3>
+     * <p>마지막으로 조회한 `endDate`보다 최신인 안건을 가져옵니다.</p>
+     *
+     * @param endDate  마지막 조회된 안건의 종료 날짜
+     * @param agendaId 마지막 조회된 안건의 ID
+     * @return BooleanExpression - 조건식 반환
+     */
+    private BooleanExpression gtEndDateOrEqEndDateAndGtId(LocalDate endDate, Long agendaId) {
+        if (endDate == null && agendaId == null) {
+            return null;
+        }
+        return agenda.endDate.gt(endDate).or(agenda.endDate.eq(endDate).and(agenda.id.gt(agendaId)));
+    }
+
+    /**
+     * <h3>커서 기반 무한 스크롤 지원 - 종료 날짜 기준 조회 (과거 데이터)</h3>
+     * <p>마지막으로 조회한 `endDate`보다 오래된 안건을 가져옵니다.</p>
+     *
+     * @param endDate  마지막 조회된 안건의 종료 날짜
+     * @param agendaId 마지막 조회된 안건의 ID
+     * @return BooleanExpression - 조건식 반환
+     */
+    private BooleanExpression ltEndDateOrEqEndDateAndGtId(LocalDate endDate, Long agendaId) {
+        if (endDate == null && agendaId == null) {
+            return null;
+        }
+        return agenda.endDate.lt(endDate).or(agenda.endDate.eq(endDate).and(agenda.id.gt(agendaId)));
+    }
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/CustomAgendaRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/CustomAgendaRepository.java
@@ -1,0 +1,17 @@
+package com.bungeobbang.backend.agenda.domain.repository;
+
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CustomAgendaRepository {
+    // 시작 전 답해요 조회
+    List<AgendaResponse> getUpcomingAgendas(Long universityId, LocalDate endDate, Long agendaId);
+
+    // 진행 중인 답해요 조회
+    List<AgendaResponse> getActiveAgendas(Long universityId, LocalDate endDate, Long agendaId);
+
+    // 완료된 답해요 조회
+    List<AgendaResponse> getClosedAgendas(Long universityId, LocalDate endDate, Long agendaId);
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/dto/response/AgendaResponse.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/dto/response/AgendaResponse.java
@@ -1,0 +1,15 @@
+package com.bungeobbang.backend.agenda.dto.response;
+
+import com.bungeobbang.backend.common.type.CategoryType;
+
+import java.time.LocalDate;
+
+public record AgendaResponse(
+        Long agendaId,
+        CategoryType categoryType,
+        String title,
+        LocalDate startDate,
+        LocalDate endDate,
+        int count
+) {
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AdminAgendaController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AdminAgendaController.java
@@ -3,8 +3,10 @@ package com.bungeobbang.backend.agenda.presentation;
 import com.bungeobbang.backend.agenda.dto.request.AgendaCreationRequest;
 import com.bungeobbang.backend.agenda.dto.request.AgendaEditRequest;
 import com.bungeobbang.backend.agenda.dto.response.AgendaCreationResponse;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
 import com.bungeobbang.backend.agenda.presentation.api.AdminAgendaApi;
 import com.bungeobbang.backend.agenda.service.AdminAgendaService;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
 import com.bungeobbang.backend.auth.admin.AdminAuth;
 import com.bungeobbang.backend.auth.domain.Accessor;
 import jakarta.validation.Valid;
@@ -12,13 +14,26 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
 
 
 @RestController
 @RequiredArgsConstructor
 public class AdminAgendaController implements AdminAgendaApi {
     private final AdminAgendaService adminAgendaService;
+
+    @Override
+    public ResponseEntity<List<AgendaResponse>> getAgendasByStatus(
+            @AdminAuth Accessor accessor,
+            @RequestParam AgendaStatusType status,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) Long agendaId) {
+        return ResponseEntity.ok(adminAgendaService.getAgendasByStatus(accessor.id(), status, endDate, agendaId));
+    }
 
     @Override
     public ResponseEntity<AgendaCreationResponse> createAgenda(

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AgendaController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AgendaController.java
@@ -1,17 +1,20 @@
 package com.bungeobbang.backend.agenda.presentation;
 
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
 import com.bungeobbang.backend.agenda.service.AgendaService;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+import com.bungeobbang.backend.auth.admin.AdminAuth;
 import com.bungeobbang.backend.auth.domain.Accessor;
 import com.bungeobbang.backend.auth.member.Auth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
-@RequestMapping("/student/agenda")
+@RequestMapping("/student/agendas")
 @RequiredArgsConstructor
 public class AgendaController {
     private final AgendaService agendaService;
@@ -22,6 +25,15 @@ public class AgendaController {
             @PathVariable Long agendaId) {
         agendaService.participateAgenda(accessor.id(), agendaId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AgendaResponse>> getAgendasByStatus(
+            @AdminAuth Accessor accessor,
+            @RequestParam AgendaStatusType status,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) Long agendaId) {
+        return ResponseEntity.ok(agendaService.getAgendasByStatus(accessor.id(), status, endDate, agendaId));
     }
 
 }

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AgendaController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/AgendaController.java
@@ -3,7 +3,6 @@ package com.bungeobbang.backend.agenda.presentation;
 import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
 import com.bungeobbang.backend.agenda.service.AgendaService;
 import com.bungeobbang.backend.agenda.status.AgendaStatusType;
-import com.bungeobbang.backend.auth.admin.AdminAuth;
 import com.bungeobbang.backend.auth.domain.Accessor;
 import com.bungeobbang.backend.auth.member.Auth;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class AgendaController {
 
     @GetMapping
     public ResponseEntity<List<AgendaResponse>> getAgendasByStatus(
-            @AdminAuth Accessor accessor,
+            @Auth Accessor accessor,
             @RequestParam AgendaStatusType status,
             @RequestParam(required = false) LocalDate endDate,
             @RequestParam(required = false) Long agendaId) {

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/api/AdminAgendaApi.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/presentation/api/AdminAgendaApi.java
@@ -3,6 +3,8 @@ package com.bungeobbang.backend.agenda.presentation.api;
 import com.bungeobbang.backend.agenda.dto.request.AgendaCreationRequest;
 import com.bungeobbang.backend.agenda.dto.request.AgendaEditRequest;
 import com.bungeobbang.backend.agenda.dto.response.AgendaCreationResponse;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
 import com.bungeobbang.backend.auth.admin.AdminAuth;
 import com.bungeobbang.backend.auth.domain.Accessor;
 import com.bungeobbang.backend.common.exception.response.ErrorResponse;
@@ -16,9 +18,33 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Tag(name = "학생회 답해요 관련 API", description = "학생회가 답해요 안건을 관리하는 API")
-@RequestMapping("/admin/agenda")
+@RequestMapping("/admin/agendas")
 public interface AdminAgendaApi {
+
+    @Operation(
+            summary = "안건 상태별 조회",
+            description = "관리자가 특정 상태(진행 전, 진행 중, 완료)에 해당하는 안건 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공적으로 안건 목록을 반환",
+                    content = @Content(schema = @Schema(implementation = AgendaResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생", content = @Content)
+    })
+
+    @GetMapping
+    ResponseEntity<List<AgendaResponse>> getAgendasByStatus(
+            @AdminAuth Accessor accessor,
+            @RequestParam AgendaStatusType status,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) Long agendaId
+    );
 
     @Operation(
             summary = "답해요 안건 생성",

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
@@ -4,6 +4,10 @@ import com.bungeobbang.backend.agenda.domain.Agenda;
 import com.bungeobbang.backend.agenda.domain.AgendaMember;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaMemberRepository;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaRepository;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.service.strategies.AgendaFinder;
+import com.bungeobbang.backend.agenda.service.strategies.AgendaFinders;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
 import com.bungeobbang.backend.common.exception.AgendaException;
 import com.bungeobbang.backend.common.exception.ErrorCode;
 import com.bungeobbang.backend.common.exception.MemberException;
@@ -12,16 +16,19 @@ import com.bungeobbang.backend.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AgendaService {
     private final AgendaMemberRepository agendaMemberRepository;
     private final AgendaRepository agendaRepository;
     private final MemberRepository memberRepository;
+    private final AgendaFinders agendaFinders;
 
     public void participateAgenda(Long memberId, Long agendaId) {
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(ErrorCode.INVALID_MEMBER));
+        final Member member = getMember(memberId);
 
         final Agenda agenda = agendaRepository.findById(agendaId)
                 .orElseThrow(() -> new AgendaException(ErrorCode.INVALID_AGENDA));
@@ -35,5 +42,17 @@ public class AgendaService {
                 .member(member)
                 .build()
         );
+    }
+
+    public List<AgendaResponse> getAgendasByStatus(Long memberId, AgendaStatusType status, LocalDate endDate, Long agendaId) {
+        final Member member = getMember(memberId);
+
+        final AgendaFinder finder = agendaFinders.mapping(status);
+        return finder.findAllByStatus(member.getUniversity().getId(), endDate, agendaId);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.INVALID_MEMBER));
     }
 }

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/ActiveAgendaFinder.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/ActiveAgendaFinder.java
@@ -1,0 +1,29 @@
+package com.bungeobbang.backend.agenda.service.strategies;
+
+import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaRepository;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.bungeobbang.backend.agenda.status.AgendaStatusType.ACTIVE;
+
+@Service
+@RequiredArgsConstructor
+public class ActiveAgendaFinder implements AgendaFinder {
+    private final CustomAgendaRepository customAgendaRepository;
+
+    @Override
+    public List<AgendaResponse> findAllByStatus(Long universityId, LocalDate endDate, Long agendaId) {
+        return customAgendaRepository.getActiveAgendas(universityId, endDate, agendaId);
+    }
+
+    @Override
+    public AgendaStatusType getStatus() {
+        return ACTIVE;
+    }
+}
+

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/AgendaFinder.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/AgendaFinder.java
@@ -1,0 +1,13 @@
+package com.bungeobbang.backend.agenda.service.strategies;
+
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AgendaFinder {
+    List<AgendaResponse> findAllByStatus(Long universityId, LocalDate endDate, Long agendaId);
+
+    AgendaStatusType getStatus();
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/AgendaFinders.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/AgendaFinders.java
@@ -1,0 +1,24 @@
+package com.bungeobbang.backend.agenda.service.strategies;
+
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+import com.bungeobbang.backend.common.exception.AgendaException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.bungeobbang.backend.common.exception.ErrorCode.NOT_SUPPORT_STATUS;
+
+@Component
+public class AgendaFinders {
+    List<AgendaFinder> strategies;
+
+    public AgendaFinders(List<AgendaFinder> strategies) {
+        this.strategies = strategies;
+    }
+
+    public AgendaFinder mapping(final AgendaStatusType statusType) {
+        return strategies.stream().filter(
+                strategy -> strategy.getStatus().equals(statusType)
+        ).findFirst().orElseThrow(() -> new AgendaException(NOT_SUPPORT_STATUS));
+    }
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/ClosedAgendaFinder.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/ClosedAgendaFinder.java
@@ -1,0 +1,29 @@
+package com.bungeobbang.backend.agenda.service.strategies;
+
+import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaRepository;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.bungeobbang.backend.agenda.status.AgendaStatusType.CLOSED;
+
+@Service
+@RequiredArgsConstructor
+public class ClosedAgendaFinder implements AgendaFinder {
+    private final CustomAgendaRepository customAgendaRepository;
+
+    @Override
+    public List<AgendaResponse> findAllByStatus(Long universityId, LocalDate endDate, Long agendaId) {
+        return customAgendaRepository.getClosedAgendas(universityId, endDate, agendaId);
+    }
+
+    @Override
+    public AgendaStatusType getStatus() {
+        return CLOSED;
+    }
+}
+

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/UpcomingAgendaFinder.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/strategies/UpcomingAgendaFinder.java
@@ -1,0 +1,29 @@
+package com.bungeobbang.backend.agenda.service.strategies;
+
+import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaRepository;
+import com.bungeobbang.backend.agenda.dto.response.AgendaResponse;
+import com.bungeobbang.backend.agenda.status.AgendaStatusType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.bungeobbang.backend.agenda.status.AgendaStatusType.UPCOMING;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingAgendaFinder implements AgendaFinder {
+    private final CustomAgendaRepository customAgendaRepository;
+
+    @Override
+    public List<AgendaResponse> findAllByStatus(Long universityId, LocalDate endDate, Long agendaId) {
+        return customAgendaRepository.getUpcomingAgendas(universityId, endDate, agendaId);
+    }
+
+    @Override
+    public AgendaStatusType getStatus() {
+        return UPCOMING;
+    }
+}
+

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/status/AgendaStatusType.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/status/AgendaStatusType.java
@@ -1,0 +1,7 @@
+package com.bungeobbang.backend.agenda.status;
+
+public enum AgendaStatusType {
+    UPCOMING,
+    ACTIVE,
+    CLOSED,
+}

--- a/backend/src/main/java/com/bungeobbang/backend/common/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/bungeobbang/backend/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.bungeobbang.backend.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- **답해요 채팅방 목록 조회 API 구현**
- **전략 패턴(Strategy Pattern) 적용하여 상태별 채팅방 조회 로직 분리**
- **QueryDSL을 활용한 무한 스크롤 동적 쿼리 적용**
- **API 성능 개선 및 코드 유지보수성을 고려한 설계 반영**

---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
-->
- **전략 패턴 적용 (`AgendaFinder`)**
  - `strategies` 패키지 내에 `finder` 구현 클래스 추가  
  - 상태별(예정, 진행 중, 종료됨) 조회 전략을 개별 클래스로 분리  
- **QueryDSL 기반 무한스크롤 동적 쿼리 구현**
  - `CustomAgendaRepositoryImpl`에서 `endDate`, `agendaId`를 활용한 커서 기반 페이징 적용  
  - `orderBy` 조건을 추가하여 정렬 기준 명확화  
- **API 응답 속도 최적화**
  - `select` 시 필요한 필드만 조회하도록 최적화  
  - `limit` 적용하여 한 번에 조회하는 데이터 수 제한  

---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
-->
- **전략 패턴 적용 (`AgendaFinder` 인터페이스 및 구현 클래스 추가)**
  - `UpcomingAgendaFinder` (예정된 채팅방 조회)
  - `ActiveAgendaFinder` (진행 중인 채팅방 조회)
  - `ClosedAgendaFinder` (종료된 채팅방 조회)
  - `AgendaFinderFactory`를 통해 상태별 `Finder` 자동 매핑  
- **QueryDSL을 이용한 무한 스크롤 동적 쿼리 추가**
  - `gtEndDateOrEqEndDateAndGtId()` 메서드 구현
  - `ltEndDateOrEqEndDateAndGtId()` 메서드 구현


[QueryDSL CVE](https://www.mend.io/vulnerability-database/CVE-2024-49203?utm_source=JetBrains) 관련
코드에서는 OrderBy에 사용자의 입력값이 들어가지 않아 괜찮을 것 같습니다.

---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
-->
- **Closes #94""
- **관련 링크:** [JIRA, Trello 등 링크]

채팅방 조회 쿼리는 [API문서](https://www.notion.so/bside/fc47eba483764653961a596df294f34e?pvs=4#82a3faa20afc4dc0827155f5221cda3b) 확인해주세요~~~ 

---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
-->
- [ ] **전략 패턴 적용 방식 검토 요청** (`AgendaFinder` 전략이 적절한지 확인)  
- [ ] **QueryDSL 동적 쿼리 검토 요청** (`orderBy`, `where` 조건 최적화 필요 여부)  

