### PR TITLE
[Fix/BE/#151] 답해요 채팅 정렬 순서 수정

### DIFF
--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/AgendaAdminLastReadChat.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/AgendaAdminLastReadChat.java
@@ -1,0 +1,28 @@
+package com.bungeobbang.backend.agenda.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "agenda_last_read_chat")
+@Getter
+public class AgendaAdminLastReadChat {
+    @Id
+    private ObjectId id;
+
+    private Long adminId;
+
+    private Long agendaId;
+
+    private ObjectId lastReadChatId;
+
+    @Builder
+    public AgendaAdminLastReadChat(ObjectId id, Long adminId, Long agendaId, ObjectId lastReadChatId) {
+        this.id = id;
+        this.adminId = adminId;
+        this.agendaId = agendaId;
+        this.lastReadChatId = lastReadChatId;
+    }
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AdminLastReadChatRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AdminLastReadChatRepository.java
@@ -1,0 +1,13 @@
+package com.bungeobbang.backend.agenda.domain.repository;
+
+import com.bungeobbang.backend.agenda.domain.AgendaAdminLastReadChat;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminLastReadChatRepository extends MongoRepository<AgendaAdminLastReadChat, ObjectId> {
+    Optional<AgendaAdminLastReadChat> findByAdminIdAndAgendaId(Long adminId, Long agendaId);
+}

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaChatRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaChatRepository.java
@@ -11,14 +11,13 @@ import java.util.List;
 
 @Repository
 public interface AgendaChatRepository extends MongoRepository<AgendaChat, String> {
-    @Query(value = "{ 'agendaId' : ?0, _id : { $lt :  ?2 }}", sort = "{ _id : -1 }")
-    List<AgendaChat> findAllByAgendaIdAndIdLessThan(Long agendaId, Boolean admin, ObjectId id, Pageable pageable);
+    @Query(value = "{ 'agendaId' : ?0, _id : { $lt :  ?1 }}"
+            , sort = "{ _id : -1 }")
+    List<AgendaChat> findChatsByAgendaIdAndIdLessThan(Long agendaId, ObjectId id, Pageable pageable);
 
-    @Query(value = "{ 'agendaId' : ?0}", sort = "{ _id : 1 }")
-    List<AgendaChat> findAllByAgendaId(Long agendaId, Boolean admin, Pageable pageable);
-
-    @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ] }", sort = "{ '_id' : -1 }")
-    List<AgendaChat> findChatsByAgendaIdAndMemberId(Long agendaId, Long memberId, Pageable pageable);
+    @Query(value = "{ 'agendaId' : ?0, '_id' : { $gte: ?1 } }",
+            sort = "{ '_id' : -1 }")
+    List<AgendaChat> findChatsByAgendaIdAndIdGreaterThan(Long agendaId, ObjectId id);
 
     @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ], '_id' : { $lt: ?2 } }",
             sort = "{ '_id' : -1 }")

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaChatRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaChatRepository.java
@@ -14,13 +14,17 @@ public interface AgendaChatRepository extends MongoRepository<AgendaChat, String
     @Query(value = "{ 'agendaId' : ?0, _id : { $lt :  ?2 }}", sort = "{ _id : -1 }")
     List<AgendaChat> findAllByAgendaIdAndIdLessThan(Long agendaId, Boolean admin, ObjectId id, Pageable pageable);
 
-    @Query(value = "{ 'agendaId' : ?0}", sort = "{ _id : -1 }")
+    @Query(value = "{ 'agendaId' : ?0}", sort = "{ _id : 1 }")
     List<AgendaChat> findAllByAgendaId(Long agendaId, Boolean admin, Pageable pageable);
 
     @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ] }", sort = "{ '_id' : -1 }")
     List<AgendaChat> findChatsByAgendaIdAndMemberId(Long agendaId, Long memberId, Pageable pageable);
 
-    @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ] ,_id : { $lt :  ?2 }}", sort = "{ '_id' : -1 }")
+    @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ], '_id' : { $lt: ?2 } }",
+            sort = "{ '_id' : -1 }")
     List<AgendaChat> findChatsByAgendaIdAndMemberIdAndIdLessThan(Long agendaId, Long memberId, ObjectId id, Pageable pageable);
 
+    @Query(value = "{ 'agendaId' : ?0, $or: [ { 'memberId': ?1 }, { 'isAdmin': true } ], '_id' : { $gte: ?2 } }",
+            sort = "{ '_id' : -1 }")
+    List<AgendaChat> findChatsByAgendaIdAndMemberIdAndIdGreaterThan(Long agendaId, Long memberId, ObjectId id);
 }

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaLastReadChatRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaLastReadChatRepository.java
@@ -5,7 +5,9 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AgendaLastReadChatRepository extends MongoRepository<AgendaLastReadChat, ObjectId> {
-    AgendaLastReadChat findByMemberIdAndAgendaId(Long memberId, Long agendaId);
+    Optional<AgendaLastReadChat> findByMemberIdAndAgendaId(Long memberId, Long agendaId);
 }

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AdminAgendaChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AdminAgendaChatService.java
@@ -1,6 +1,8 @@
 package com.bungeobbang.backend.agenda.service;
 
+import com.bungeobbang.backend.agenda.domain.AgendaAdminLastReadChat;
 import com.bungeobbang.backend.agenda.domain.AgendaChat;
+import com.bungeobbang.backend.agenda.domain.repository.AdminLastReadChatRepository;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaChatRepository;
 import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaChatRepository;
 import com.bungeobbang.backend.agenda.dto.request.AgendaChatRequest;
@@ -11,7 +13,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * ✅ 관리자용 답해요 채팅 서비스 (무한 스크롤 지원)
@@ -25,10 +29,13 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AdminAgendaChatService {
-    private static final int CHAT_SIZE = 10;
+
     private final AgendaChatRepository agendaChatRepository;
-    private static final ObjectId MAX_OBJECT_ID = new ObjectId("ffffffffffffffffffffffff");
+    private static final int CHAT_SIZE = 10;
+    private static final ObjectId MIN_OBJECT_ID = new ObjectId(0, 0);
     private final CustomAgendaChatRepository customAgendaChatRepository;
+    private final AdminLastReadChatRepository agendaLastReadChatRepository;
+    private static final ObjectId MAX_OBJECT_ID = new ObjectId("ffffffffffffffffffffffff");
 
     /**
      * ✅ 답해요 채팅 내역 조회 (무한 스크롤 방식)
@@ -40,22 +47,47 @@ public class AdminAgendaChatService {
      * @return `AgendaChatResponse` 리스트 (최대 10개)
      */
     public List<AgendaChatResponse> getChats(Long adminId, Long agendaId, ObjectId chatId) {
-
         Pageable pageable = PageRequest.of(0, CHAT_SIZE);
 
-        // ✅ 최신 채팅 10개 조회 (첫 페이지)
         if (chatId == null) {
-            return agendaChatRepository.findAllByAgendaId(agendaId, true, pageable)
+            // 사용자의 마지막 읽은 채팅 가져오기
+            AgendaAdminLastReadChat lastReadChat = agendaLastReadChatRepository.findByAdminIdAndAgendaId(adminId, agendaId)
+                    .orElse(new AgendaAdminLastReadChat(null, null, null, MIN_OBJECT_ID));
+            ObjectId lastReadChatId = lastReadChat.getLastReadChatId();
+
+            // lastReadChatId보다 작은 채팅 가져오기
+            List<AgendaChatResponse> chats = agendaChatRepository
+                    .findChatsByAgendaIdAndIdLessThan(agendaId, lastReadChatId, pageable)
                     .stream()
                     .map(AgendaChatResponse::from)
-                    .toList();
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.reverse(list); // 🔹 리스트 역순 정렬
+                        return list;
+                    }));
+
+            // lastReadChatId보다 큰 채팅 가져오기
+            List<AgendaChatResponse> afterChats = agendaChatRepository
+                    .findChatsByAgendaIdAndIdGreaterThan(agendaId, lastReadChatId)
+                    .stream()
+                    .map(AgendaChatResponse::from)
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.reverse(list); // 🔹 리스트 역순 정렬
+                        return list;
+                    }));
+
+            chats.addAll(afterChats); // 최종 리스트 합치기
+
+            return chats;
         }
 
         // ✅ 특정 `chatId` 이전의 채팅 10개 조회 (무한 스크롤)
-        return agendaChatRepository.findAllByAgendaIdAndIdLessThan(agendaId, true, chatId, pageable)
+        return agendaChatRepository.findChatsByAgendaIdAndIdLessThan(agendaId, chatId, pageable)
                 .stream()
                 .map(AgendaChatResponse::from)
-                .toList();
+                .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                    Collections.reverse(list);
+                    return list;
+                }));
     }
 
     public void saveChat(AgendaChatRequest request) {

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
@@ -52,7 +52,7 @@ public class AgendaChatService {
         if (chatId == null) {
             // 사용자의 마지막 읽은 채팅 가져오기
             AgendaLastReadChat lastReadChat = agendaLastReadChatRepository.findByMemberIdAndAgendaId(memberId, agendaId)
-                    .orElse(new AgendaLastReadChat(MIN_OBJECT_ID, null, null, null));
+                    .orElse(new AgendaLastReadChat(null, null, null, MIN_OBJECT_ID));
             ObjectId lastReadChatId = lastReadChat.getLastReadChatId();
 
             // lastReadChatId보다 작은 채팅 가져오기

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
@@ -1,7 +1,9 @@
 package com.bungeobbang.backend.agenda.service;
 
 import com.bungeobbang.backend.agenda.domain.AgendaChat;
+import com.bungeobbang.backend.agenda.domain.AgendaLastReadChat;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaChatRepository;
+import com.bungeobbang.backend.agenda.domain.repository.AgendaLastReadChatRepository;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaMemberRepository;
 import com.bungeobbang.backend.agenda.domain.repository.CustomAgendaChatRepository;
 import com.bungeobbang.backend.agenda.dto.request.AgendaChatRequest;
@@ -14,7 +16,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * ✅ 학생용 답해요 채팅 서비스 (무한 스크롤 지원)
@@ -22,11 +26,13 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AgendaChatService {
-    private static final int CHAT_SIZE = 10;
     private final AgendaChatRepository agendaChatRepository;
     private final AgendaMemberRepository agendaMemberRepository;
-    private static final ObjectId MAX_OBJECT_ID = new ObjectId("ffffffffffffffffffffffff");
     private final CustomAgendaChatRepository customAgendaChatRepository;
+    private static final int CHAT_SIZE = 10;
+    private static final ObjectId MIN_OBJECT_ID = new ObjectId(0, 0);
+    private static final ObjectId MAX_OBJECT_ID = new ObjectId("ffffffffffffffffffffffff");
+    private final AgendaLastReadChatRepository agendaLastReadChatRepository;
 
     /**
      * ✅ 답해요 채팅 내역 조회 (무한 스크롤 방식)
@@ -44,16 +50,44 @@ public class AgendaChatService {
         }
 
         if (chatId == null) {
-            return agendaChatRepository.findChatsByAgendaIdAndMemberId(agendaId, memberId, pageable)
+            // 사용자의 마지막 읽은 채팅 가져오기
+            AgendaLastReadChat lastReadChat = agendaLastReadChatRepository.findByMemberIdAndAgendaId(memberId, agendaId)
+                    .orElse(new AgendaLastReadChat(MIN_OBJECT_ID, null, null, null));
+            ObjectId lastReadChatId = lastReadChat.getLastReadChatId();
+
+            // lastReadChatId보다 작은 채팅 가져오기
+            List<AgendaChatResponse> chats = agendaChatRepository
+                    .findChatsByAgendaIdAndMemberIdAndIdLessThan(agendaId, memberId, lastReadChatId, pageable)
                     .stream()
                     .map(AgendaChatResponse::from)
-                    .toList();
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.reverse(list); // 🔹 리스트 역순 정렬
+                        return list;
+                    }));
+
+            // lastReadChatId보다 큰 채팅 가져오기
+            List<AgendaChatResponse> afterChats = agendaChatRepository
+                    .findChatsByAgendaIdAndMemberIdAndIdGreaterThan(agendaId, memberId, lastReadChatId)
+                    .stream()
+                    .map(AgendaChatResponse::from)
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                        Collections.reverse(list); // 🔹 리스트 역순 정렬
+                        return list;
+                    }));
+
+            chats.addAll(afterChats); // 최종 리스트 합치기
+
+            return chats;
         }
+
 
         return agendaChatRepository.findChatsByAgendaIdAndMemberIdAndIdLessThan(agendaId, memberId, chatId, pageable)
                 .stream()
                 .map(AgendaChatResponse::from)
-                .toList();
+                .collect(Collectors.collectingAndThen(Collectors.toList(), list -> {
+                    Collections.reverse(list); // 🔹 리스트 역순 정렬
+                    return list;
+                }));
     }
 
     public void saveChat(AgendaChatRequest request) {

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
@@ -1,6 +1,7 @@
 package com.bungeobbang.backend.agenda.service;
 
 import com.bungeobbang.backend.agenda.domain.Agenda;
+import com.bungeobbang.backend.agenda.domain.AgendaLastReadChat;
 import com.bungeobbang.backend.agenda.domain.AgendaMember;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaLastReadChatRepository;
 import com.bungeobbang.backend.agenda.domain.repository.AgendaMemberRepository;
@@ -197,6 +198,7 @@ public class AgendaService {
      */
     private ObjectId getLastReadChat(final Long agendaId, final Long memberId) {
         return agendaLastReadChatRepository.findByMemberIdAndAgendaId(memberId, agendaId)
+                .orElse(new AgendaLastReadChat(MIN_OBJECT_ID, null, null, null))
                 .getLastReadChatId();
     }
 

--- a/backend/src/test/java/com/bungeobbang/backend/agenda/service/AgendaServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/agenda/service/AgendaServiceTest.java
@@ -199,7 +199,7 @@ class AgendaServiceTest {
                                 new LastChat(1L, new ObjectId(0, 0), "1번 마지막 채팅", LocalDateTime.now())
                         ));
         when(agendaLastReadChatRepository.findByMemberIdAndAgendaId(anyLong(), anyLong()))
-                .thenReturn(new AgendaLastReadChat(new ObjectId(0, 0), member.getId(), agenda.getId(), new ObjectId(0, 0)));
+                .thenReturn(Optional.of(new AgendaLastReadChat(new ObjectId(0, 0), member.getId(), agenda.getId(), new ObjectId(0, 0))));
 
         // when
         final List<MyAgendaResponse> myAgenda = agendaService.getMyAgenda(member.getId());


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 내림차순으로 되어있던 채팅 데이터를 오름차순으로 반환하도록 수정하였습니다
- 


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 학생회 마지막 읽은 채팅도 저장하기 위해 AgendaAdminLastRead 클래스 생성
- 첫조회 시 마지막 읽은 채팅부터 조회하도록 하였습니다


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- lastReadChat 조회는 Optional로 받아 없을 경우 ObjectId값을 가장 작은 값으로 세팅하여 첫 채팅부터 조회할 수 있게 하였습니다~~~
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #151
- 관련 링크: 

![image](https://github.com/user-attachments/assets/1740dfcc-0d7c-45de-8628-ab7e5c1b35ae)

---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
