### PR TITLE
[Fix/BE/#265] 말해요 진입페이지 통계 로직 수정

### DIFF
--- a/backend/src/main/java/com/bungeobbang/backend/opinion/domain/repository/OpinionRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/domain/repository/OpinionRepository.java
@@ -22,4 +22,7 @@ public interface OpinionRepository extends JpaRepository<Opinion, Long> {
     List<Opinion> findAllByMemberId(Long memberId);
 
     List<Opinion> findAllByUniversityId(Long universityId);
+
+    Long countByCreatedAtBetweenAndUniversityId(LocalDateTime localDateTime, LocalDateTime now, Long id);
+
 }

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/dto/response/OpinionStatisticsResponse.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/dto/response/OpinionStatisticsResponse.java
@@ -1,7 +1,7 @@
 package com.bungeobbang.backend.opinion.dto.response;
 
 public record OpinionStatisticsResponse(
-        Integer opinionCount,
+        Long opinionCount,
         Integer adminResponseRate
 ) {
 }

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/presentation/MemberOpinionController.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/presentation/MemberOpinionController.java
@@ -27,10 +27,10 @@ public class MemberOpinionController implements MemberOpinionApi {
 
     @MemberOnly
     @GetMapping()
-    public ResponseEntity<OpinionStatisticsResponse> getOpinionStatistics(
+    public ResponseEntity<OpinionStatisticsResponse> getRecentMonthlyOpinionStatistics(
             @Auth final Accessor accessor) {
         return ResponseEntity.ok()
-                .body(memberOpinionService.computeOpinionStatistics(accessor.id()));
+                .body(memberOpinionService.computeRecentMonthlyOpinionStatistics(accessor.id()));
     }
 
     @MemberOnly

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/presentation/api/MemberOpinionApi.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/presentation/api/MemberOpinionApi.java
@@ -43,7 +43,7 @@ public interface MemberOpinionApi {
     })
     @GetMapping
     @MemberOnly
-    ResponseEntity<OpinionStatisticsResponse> getOpinionStatistics(
+    ResponseEntity<OpinionStatisticsResponse> getRecentMonthlyOpinionStatistics(
             @Parameter(hidden = true) @Auth Accessor accessor
     );
 

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/service/MemberOpinionService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/service/MemberOpinionService.java
@@ -8,6 +8,7 @@ import com.bungeobbang.backend.member.domain.repository.MemberRepository;
 import com.bungeobbang.backend.opinion.domain.Opinion;
 import com.bungeobbang.backend.opinion.domain.OpinionChat;
 import com.bungeobbang.backend.opinion.domain.OpinionLastRead;
+import com.bungeobbang.backend.opinion.domain.repository.AnsweredOpinionRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionChatRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionLastReadRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionRepository;
@@ -23,10 +24,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.bungeobbang.backend.opinion.service.AdminOpinionService.ASIA_SEOUL;
 
 /**
  * 학생이 사용하는 말해요 관련 서비스 로직을 처리하는 클래스.
@@ -40,6 +45,7 @@ public class MemberOpinionService {
     private final OpinionChatRepository opinionChatRepository;
     private final MemberRepository memberRepository;
     private final OpinionLastReadRepository opinionLastReadRepository;
+    private final AnsweredOpinionRepository answeredOpinionRepository;
     private static final String MIN_OBJECT_ID = "000000000000000000000000";
 
     /**
@@ -49,22 +55,19 @@ public class MemberOpinionService {
      * @return OpinionStatisticsResponse 1달간 말해요 통계 응답 객체
      * @throws MemberException 학생 정보를 조회할 수 없는 경우 예외 발생
      */
-    public OpinionStatisticsResponse computeOpinionStatistics(final Long memberId) {
+    public OpinionStatisticsResponse computeRecentMonthlyOpinionStatistics(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(ErrorCode.INVALID_MEMBER));
-        final List<Opinion> opinions = opinionRepository.findAllByCreatedAtBetweenAndUniversityId(
-                LocalDateTime.now().minusMonths(1L),
+
+        LocalDateTime startDateTime = LocalDateTime.now().minusMonths(1);
+        LocalDateTime endDateTime = LocalDateTime.now();
+        final Long opinionCount = opinionRepository.countByCreatedAtBetweenAndUniversityId(
+                LocalDateTime.now().minusMonths(1),
                 LocalDateTime.now(),
-                member.getUniversity().getId());
-        final List<Long> opinionIds = opinions.stream()
-                .map(Opinion::getId)
-                .toList();
-
-        final List<Long> opinionChats = opinionChatRepository.findDistinctOpinionIdByIsAdminTrue(opinionIds);
-
-        final int opinionCount = opinions.size();
-        final int responseCount = opinionChats.size();
-        final double rawRate = (double) responseCount / opinionCount;
+                member.getUniversity().getId()
+        );
+        final Long answerCount = getAnsweredCountByPeriod(startDateTime, endDateTime, member.getUniversity().getId());
+        final double rawRate = (double) answerCount / opinionCount;
         final int adminResponseRate = (int) Math.round(rawRate * 100);
         return new OpinionStatisticsResponse(opinionCount, adminResponseRate);
     }
@@ -232,5 +235,14 @@ public class MemberOpinionService {
                 })
                 .sorted()
                 .toList();
+    }
+
+    private Long getAnsweredCountByPeriod(final LocalDateTime startDateTime, final LocalDateTime endDateTime, final Long universityId) {
+        final ZoneId koreaZone = ZoneId.of(ASIA_SEOUL);
+
+        final ObjectId startObjectId = new ObjectId(new Date(startDateTime.atZone(koreaZone).toInstant().toEpochMilli()));
+        final ObjectId endObjectId = new ObjectId(new Date(endDateTime.atZone(koreaZone).toInstant().toEpochMilli()));
+
+        return answeredOpinionRepository.countByIdBetweenAndUniversityId(startObjectId, endObjectId, universityId);
     }
 }

--- a/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
@@ -10,6 +10,7 @@ import com.bungeobbang.backend.opinion.domain.Opinion;
 import com.bungeobbang.backend.opinion.domain.OpinionChat;
 import com.bungeobbang.backend.opinion.domain.OpinionLastRead;
 import com.bungeobbang.backend.opinion.domain.OpinionType;
+import com.bungeobbang.backend.opinion.domain.repository.AnsweredOpinionRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionChatRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionLastReadRepository;
 import com.bungeobbang.backend.opinion.domain.repository.OpinionRepository;
@@ -52,22 +53,20 @@ class MemberOpinionServiceTest {
     private MemberRepository memberRepository;
     @Mock
     private OpinionLastReadRepository opinionLastReadRepository;
+    @Mock
+    private AnsweredOpinionRepository answeredOpinionRepository;
 
     @Test
     @DisplayName("1개월 동안의 의견 통계를 계산한다.")
     void computeOpinionStatistics() {
         // given
         Member member = NAVER_MEMBER;
-        Opinion opinion1 = NAVER_OPINION1;
-        Opinion opinion2 = NAVER_OPINION2;
-
-        List<Opinion> opinions = List.of(opinion1, opinion2);
-        List<Long> opinionIds = opinions.stream().map(Opinion::getId).toList();
 
         when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-        when(opinionRepository.findAllByCreatedAtBetweenAndUniversityId(any(), any(), anyLong()))
-                .thenReturn(opinions);
-        when(opinionChatRepository.findDistinctOpinionIdByIsAdminTrue(opinionIds)).thenReturn(List.of(1L));
+        when(opinionRepository.countByCreatedAtBetweenAndUniversityId(any(), any(), anyLong()))
+                .thenReturn(2L);
+        when(answeredOpinionRepository.countByIdBetweenAndUniversityId(any(), any(), anyLong()))
+                .thenReturn(1L);
 
         // when
         OpinionStatisticsResponse response = memberOpinionService.computeRecentMonthlyOpinionStatistics(1L);

--- a/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
@@ -70,7 +70,7 @@ class MemberOpinionServiceTest {
         when(opinionChatRepository.findDistinctOpinionIdByIsAdminTrue(opinionIds)).thenReturn(List.of(1L));
 
         // when
-        OpinionStatisticsResponse response = memberOpinionService.computeOpinionStatistics(1L);
+        OpinionStatisticsResponse response = memberOpinionService.computeRecentMonthlyOpinionStatistics(1L);
 
         // then
         assertThat(response.opinionCount()).isEqualTo(2);
@@ -82,7 +82,7 @@ class MemberOpinionServiceTest {
     void computeOpinionStatistics_InvalidMember() {
         when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> memberOpinionService.computeOpinionStatistics(1L))
+        assertThatThrownBy(() -> memberOpinionService.computeRecentMonthlyOpinionStatistics(1L))
                 .isInstanceOf(MemberException.class)
                 .hasMessage(ErrorCode.INVALID_MEMBER.getMessage());
     }


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->

- 말해요 진입페이지 통계 로직 수정


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 통계페이지와 동일한 로직으로 수정.
- 기존 : 
    - 30일 이내에 생성된 opinionIdList 조회
    - in 연산자로 OpinionChatRepository에서 isTrue인 채팅 조회
- 변경 : 
    - 30일 이내에 생성된 opinion 카운트
    - AnsweredOpinion에서 30일 이내 답변 개수 카운트


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 테스트코드 수정



---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #265 

