### PR TITLE
[Fix/BE] agenda last chat createdAt 수정

### DIFF
--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/AgendaMember.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/AgendaMember.java
@@ -25,10 +25,22 @@ public class AgendaMember {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column
+    private boolean isDeleted;
+
     @Builder
     public AgendaMember(Long id, Agenda agenda, Member member) {
         this.id = id;
         this.agenda = agenda;
         this.member = member;
+        this.isDeleted = false;
+    }
+
+    public void reParticipate() {
+        this.isDeleted = false;
+    }
+
+    public void exit() {
+        this.isDeleted = true;
     }
 }

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaMemberRepository.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/repository/AgendaMemberRepository.java
@@ -8,10 +8,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AgendaMemberRepository extends JpaRepository<AgendaMember, Long> {
-    boolean existsByMemberIdAndAgendaId(Long memberId, Long agendaId);
+    boolean existsByMemberIdAndAgendaIdAndIsDeletedFalse(Long memberId, Long agendaId);
+
+    Optional<AgendaMember> findByMemberIdAndAgendaIdAndIsDeletedTrue(Long memberId, Long agendaId);
+
+    Optional<AgendaMember> findByMemberIdAndAgendaIdAndIsDeletedFalse(Long memberId, Long agendaId);
 
     void deleteByMemberIdAndAgendaId(Long memberId, Long agendaId);
 

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaChatService.java
@@ -44,7 +44,7 @@ public class AgendaChatService {
     public List<AgendaChatResponse> getChats(Long memberId, Long agendaId, ObjectId chatId, ScrollType scrollType) {
         final boolean isEnd = agendaRepository.existsByIdAndEndDateBefore(agendaId, LocalDate.now());
         // 종료된 답해요는 누구나 조회 가능
-        if (!isEnd && !agendaMemberRepository.existsByMemberIdAndAgendaId(memberId, agendaId)) {
+        if (!isEnd && !agendaMemberRepository.existsByMemberIdAndAgendaIdAndIsDeletedFalse(memberId, agendaId)) {
             throw new AgendaException(ErrorCode.NOT_PARTICIPATED);
         }
 
@@ -76,7 +76,7 @@ public class AgendaChatService {
 
     public void validAgenda(Long agendaId) {
         final Agenda agenda = agendaRepository.findById(agendaId)
-                .orElseThrow(() -> new AgendaException(ErrorCode.AGENDA_DELETED));
+                .orElseThrow(() -> new AgendaException(ErrorCode.INVALID_AGENDA));
 
         if (agenda.getStartDate().isAfter(LocalDate.now()))
             throw new AgendaException(ErrorCode.AGENDA_NOT_STARTED);

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaRealTimeChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaRealTimeChatService.java
@@ -83,6 +83,7 @@ public class AgendaRealTimeChatService {
         log.info("☄️ AdminConnect event: {}", event);
         final List<Agenda> agendas = getAgenda(event.adminId());
         agendas.forEach(agenda -> messageQueueService.subscribe(event.session(), AGENDA_MEMBER_PREFIX + agenda.getId()));
+        agendas.forEach(agenda -> messageQueueService.subscribe(event.session(), AGENDA_ADMIN_PREFIX + agenda.getId()));
     }
 
     @EventListener
@@ -90,6 +91,7 @@ public class AgendaRealTimeChatService {
         log.info("️✂ AdminDisconnect event: {}", event);
         final List<Agenda> agendas = getAgenda(event.adminId());
         agendas.forEach(agenda -> messageQueueService.unsubscribe(event.session(), AGENDA_MEMBER_PREFIX + agenda.getId()));
+        agendas.forEach(agenda -> messageQueueService.unsubscribe(event.session(), AGENDA_ADMIN_PREFIX + agenda.getId()));
     }
 
 
@@ -118,14 +120,9 @@ public class AgendaRealTimeChatService {
      */
     public void sendMessageFromAdmin(AgendaAdminEvent event) {
         try {
-            // 메아리 전송
-            event.session().sendMessage(new TextMessage(objectMapper.writeValueAsBytes(event.websocketMessage())));
-
             messageQueueService.publish(AGENDA_ADMIN_PREFIX + event.agendaId(), objectMapper.writeValueAsString(event.websocketMessage()));
         } catch (JsonProcessingException e) {
             throw new AgendaException(JSON_PARSE_FAIL);
-        } catch (IOException e) {
-            throw new AgendaException(ECHO_SEND_FAIL);
         }
     }
 
@@ -159,6 +156,7 @@ public class AgendaRealTimeChatService {
      */
     public void connectAdminFromAgenda(WebSocketSession session, Long adminId) {
         messageQueueService.subscribe(session, AGENDA_MEMBER_PREFIX + adminId);
+        messageQueueService.subscribe(session, AGENDA_ADMIN_PREFIX + adminId);
     }
 
     /**

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
@@ -159,7 +159,7 @@ public class AgendaService {
                                     .isEnd(agenda.getEndDate().isAfter(LocalDate.now()))
                                     .title(agenda.getTitle())
                                     .categoryType(agenda.getCategoryType())
-                                    .createdAt(agenda.getCreatedAt())
+                                    .createdAt(lastChat.createdAt())
                                     .hasNew(lastChat.hasNewChat())
                                     .lastChat(lastChat.content())
                                     .lastReadChatId(lastChat.lastReadChatId())

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaService.java
@@ -74,16 +74,21 @@ public class AgendaService {
         if (!agenda.getUniversity().equals(member.getUniversity())) {
             throw new AgendaException(ErrorCode.FORBIDDEN_UNIVERSITY_ACCESS);
         }
-        if (agendaMemberRepository.existsByMemberIdAndAgendaId(memberId, agendaId)) {
+        if (agendaMemberRepository.existsByMemberIdAndAgendaIdAndIsDeletedFalse(memberId, agendaId)) {
             throw new AgendaException(ErrorCode.ALREADY_PARTICIPATED);
         }
 
-        agendaMemberRepository.save(AgendaMember.builder()
-                .agenda(agenda)
-                .member(member)
-                .build()
-        );
-        agenda.increaseParticipantCount(1);
+        // 이미 참여한 이력이 있을 경우 count하지 않고 isDeleted=false로 바꾼다.
+        agendaMemberRepository.findByMemberIdAndAgendaIdAndIsDeletedTrue(memberId, agendaId)
+                .ifPresentOrElse(AgendaMember::reParticipate, () -> {
+                            agendaMemberRepository.save(AgendaMember.builder()
+                                    .agenda(agenda)
+                                    .member(member)
+                                    .build());
+                            agenda.increaseParticipantCount(1);
+                        }
+                );
+
 
         // 현재 시점에서의 마지막 채팅을 마지막 읽은 채팅으로 저장
         final AgendaChat lastChat = memberAgendaChatRepository.findLastChat(agendaId, memberId);
@@ -178,10 +183,10 @@ public class AgendaService {
      */
     @Transactional
     public void exitAgenda(final Long memberId, final Long agendaId) {
-        if (!agendaMemberRepository.existsByMemberIdAndAgendaId(memberId, agendaId)) {
-            throw new AgendaException(AGENDA_PARTICIPATION_NOT_FOUND);
-        }
-        agendaMemberRepository.deleteByMemberIdAndAgendaId(memberId, agendaId);
+        agendaMemberRepository.findByMemberIdAndAgendaIdAndIsDeletedFalse(memberId, agendaId)
+                .ifPresentOrElse(AgendaMember::exit, () -> {
+                    throw new AgendaException(AGENDA_PARTICIPATION_NOT_FOUND);
+                });
     }
 
 

--- a/backend/src/main/java/com/bungeobbang/backend/chat/handler/AdminWebSocketChatHandler.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/handler/AdminWebSocketChatHandler.java
@@ -1,7 +1,10 @@
 package com.bungeobbang.backend.chat.handler;
 
 
+import com.bungeobbang.backend.auth.Claim;
 import com.bungeobbang.backend.auth.JwtProvider;
+import com.bungeobbang.backend.auth.domain.Authority;
+import com.bungeobbang.backend.auth.domain.repository.UuidRepository;
 import com.bungeobbang.backend.chat.event.agenda.AgendaAdminEvent;
 import com.bungeobbang.backend.chat.event.common.AdminConnectEvent;
 import com.bungeobbang.backend.chat.event.common.AdminDisconnectEvent;
@@ -9,6 +12,7 @@ import com.bungeobbang.backend.chat.event.common.AdminWebsocketMessage;
 import com.bungeobbang.backend.chat.event.opinion.OpinionAdminEvent;
 import com.bungeobbang.backend.common.exception.AuthException;
 import com.bungeobbang.backend.common.exception.BadWordException;
+import com.bungeobbang.backend.common.exception.UuidException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -22,6 +26,8 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.io.IOException;
 
 import static com.bungeobbang.backend.chat.type.SocketEventType.ERROR;
+import static com.bungeobbang.backend.common.exception.ErrorCode.DUPLICATE_LOGIN;
+import static com.bungeobbang.backend.common.exception.ErrorCode.INVALID_UUID;
 
 @Component
 @Log4j2
@@ -31,6 +37,7 @@ public class AdminWebSocketChatHandler extends TextWebSocketHandler {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
     private final ApplicationEventPublisher publisher;
+    private final UuidRepository uuidRepository;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
@@ -46,7 +53,9 @@ public class AdminWebSocketChatHandler extends TextWebSocketHandler {
         final String accessToken = (String) session.getAttributes().get(ACCESS_TOKEN);
         try {
             log.info("📚Received text message from admin: {}", message.getPayload());
-            jwtProvider.validateToken(accessToken);
+            // accessToken 검증
+            validateAccessToken(accessToken);
+
             final AdminWebsocketMessage request = objectMapper.readValue(message.getPayload(), AdminWebsocketMessage.class);
             // createdAt 생성하여 requestContainsCreatedAt 객체 생성
             final AdminWebsocketMessage requestContainsCreatedAt = AdminWebsocketMessage.createResponse(request);
@@ -72,5 +81,23 @@ public class AdminWebSocketChatHandler extends TextWebSocketHandler {
         final Long adminId = Long.valueOf(jwtProvider.getSubject(accessToken));
         publisher.publishEvent(new AdminDisconnectEvent(session, adminId));
         super.afterConnectionClosed(session, status);
+    }
+
+    private void validateAccessToken(String accessToken) {
+        jwtProvider.validateToken(accessToken);
+        final String actual = jwtProvider.getClaim(accessToken, Claim.UUID);
+        final String adminId = jwtProvider.getSubject(accessToken);
+
+        final Authority authority = Authority.valueOf(jwtProvider.getClaim(accessToken, Claim.ROLE));
+        final String expected = uuidRepository.get(authority, adminId)
+                .orElseThrow(() -> new AuthException(INVALID_UUID));
+        validateUuid(actual, expected);
+    }
+
+
+    private void validateUuid(String actual, String expected) {
+        if (!actual.equals(expected)) {
+            throw new UuidException(DUPLICATE_LOGIN);
+        }
     }
 }

--- a/backend/src/test/java/com/bungeobbang/backend/agenda/service/AgendaServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/agenda/service/AgendaServiceTest.java
@@ -11,6 +11,7 @@ import com.bungeobbang.backend.agenda.dto.response.member.MyAgendaResponse;
 import com.bungeobbang.backend.common.exception.AgendaException;
 import com.bungeobbang.backend.member.domain.Member;
 import com.bungeobbang.backend.member.domain.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,6 @@ import static com.bungeobbang.backend.agenda.fixture.AgendaFixture.NAVER_AGENDA_
 import static com.bungeobbang.backend.common.exception.ErrorCode.*;
 import static com.bungeobbang.backend.member.fixture.MemberFixture.KAKAO_MEMBER;
 import static com.bungeobbang.backend.member.fixture.MemberFixture.NAVER_MEMBER;
-import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -78,7 +78,7 @@ class AgendaServiceTest {
                 .thenReturn(Optional.of(agenda));
         when(memberRepository.findById(anyLong()))
                 .thenReturn(Optional.of(member));
-        when(agendaMemberRepository.existsByMemberIdAndAgendaId(anyLong(), anyLong()))
+        when(agendaMemberRepository.existsByMemberIdAndAgendaIdAndIsDeletedFalse(anyLong(), anyLong()))
                 .thenReturn(TRUE);
 
         // when & then
@@ -152,8 +152,8 @@ class AgendaServiceTest {
         Member member = NAVER_MEMBER;
         Agenda agenda = NAVER_AGENDA;
 
-        when(agendaMemberRepository.existsByMemberIdAndAgendaId(anyLong(), anyLong()))
-                .thenReturn(FALSE);
+        when(agendaMemberRepository.findByMemberIdAndAgendaIdAndIsDeletedFalse(anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> agendaService.exitAgenda(agenda.getId(), member.getId()))
@@ -168,14 +168,15 @@ class AgendaServiceTest {
         Member member = NAVER_MEMBER;
         Agenda agenda = NAVER_AGENDA;
 
-        when(agendaMemberRepository.existsByMemberIdAndAgendaId(anyLong(), anyLong()))
-                .thenReturn(TRUE);
+        final AgendaMember agendaMember = AgendaMember.builder().member(member).agenda(agenda).build();
+        when(agendaMemberRepository.findByMemberIdAndAgendaIdAndIsDeletedFalse(anyLong(), anyLong()))
+                .thenReturn(Optional.of(agendaMember));
 
         // when
         agendaService.exitAgenda(agenda.getId(), member.getId());
 
         // then
-        verify(agendaMemberRepository, Mockito.times(1)).deleteByMemberIdAndAgendaId(member.getId(), agenda.getId());
+        Assertions.assertThat(agendaMember.isDeleted()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 답해요 마지막 채팅 시간을 잘못 보내고 있어 수정합니다.
- 실시간 채팅을 전송할때에도 중복 로그인 체크를 추가하였습니다.
- 답해요 나가기 후 다시 참가할 경우 참여 수가 중복 카운팅되는 문제가 존재하였는데 `agendaMemger` softDelete를 이용해 해결하였습니다.
- 관리자가 보내는 메세지를 다른 관리지가 수신하지 못하는 버그 수정하였습니다.



---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- agenda createdAt 보내고 있는 버그를 lastChat createdAt으로 변경
- agendaMember isDeleted 컬럼 추가 + 학생이 나갈 경우 softDelete
- 학생회는 답해요 채널 모두를 수신한다(학생이 보내는것, 학생회가 보내는 것)

---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 테스트 코드 수정
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
