### PR TITLE
[Feat/Be/#288] 금칙어 필터링 1차 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,8 +42,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     // Redis
     implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.5.2.RELEASE'
-    // 아호코라식 알고리즘
-    implementation group: 'org.ahocorasick', name: 'ahocorasick', version: '0.6.3'
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     // password encoder

--- a/backend/src/main/java/com/bungeobbang/backend/badword/AhoCorasick.java
+++ b/backend/src/main/java/com/bungeobbang/backend/badword/AhoCorasick.java
@@ -1,0 +1,77 @@
+package com.bungeobbang.backend.badword;
+
+import java.util.*;
+
+public class AhoCorasick {
+    private static class TrieNode {
+        Map<Character, TrieNode> children = new HashMap<>();
+        TrieNode failureLink;
+        List<String> output = new ArrayList<>();
+    }
+
+    private final TrieNode root;
+
+    public AhoCorasick(List<String> keywords) {
+        root = new TrieNode();
+        buildTrie(keywords);
+        buildFailureLinks();
+    }
+
+    private void buildTrie(List<String> keywords) {
+        for (String keyword : keywords) {
+            TrieNode node = root;
+            for (char ch : keyword.toCharArray()) {
+                node = node.children.computeIfAbsent(ch, k -> new TrieNode());
+            }
+            node.output.add(keyword);
+        }
+    }
+
+    private void buildFailureLinks() {
+        Queue<TrieNode> queue = new LinkedList<>();
+        root.failureLink = root;
+        queue.add(root);
+
+        while (!queue.isEmpty()) {
+            TrieNode current = queue.poll();
+            for (Map.Entry<Character, TrieNode> entry : current.children.entrySet()) {
+                char ch = entry.getKey();
+                TrieNode child = entry.getValue();
+                TrieNode fallback = current.failureLink;
+
+                while (fallback != root && !fallback.children.containsKey(ch)) {
+                    fallback = fallback.failureLink;
+                }
+
+                if (fallback.children.containsKey(ch) && fallback.children.get(ch) != child) {
+                    child.failureLink = fallback.children.get(ch);
+                } else {
+                    child.failureLink = root;
+                }
+
+                child.output.addAll(child.failureLink.output);
+                queue.add(child);
+            }
+        }
+    }
+
+    public Map<Integer, List<String>> searchBadWords(String text) {
+        Map<Integer, List<String>> foundWords = new HashMap<>();
+        TrieNode node = root;
+
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+
+            while (node != root && !node.children.containsKey(ch)) {
+                node = node.failureLink;
+            }
+            node = node.children.getOrDefault(ch, root);
+
+            for (String word : node.output) {
+                int startIdx = i - word.length() + 1;
+                foundWords.computeIfAbsent(startIdx, k -> new ArrayList<>()).add(word);
+            }
+        }
+        return foundWords;
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 금칙어 필터링 구현



---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 아호코라식 알고리즘 구현



---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
<img width="939" alt="image" src="https://github.com/user-attachments/assets/233b8415-782f-47a1-ae75-e2923064ec1c" />

- 금칙어 약 2,500 개 기준 Trie 자료구조 4MB 메모리 차지
- 현재 : 각 노드의 자식 노드를 HashMap<Charactor, Node>으로 저장 
- Todo : Double-Array Trie 구조로 변경하여 메모리 최적화 예정



---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #288 



---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
