### PR TITLE
[Fix/BE/#333] 학생 답해요 상태별 조회 버그 수정

### DIFF
--- a/backend/src/main/java/com/bungeobbang/backend/agenda/domain/infrastructure/CustomAgendaRepositoryImpl.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/domain/infrastructure/CustomAgendaRepositoryImpl.java
@@ -139,6 +139,7 @@ public class CustomAgendaRepositoryImpl implements CustomAgendaRepository {
                         agenda.university.id.eq(universityId)
                                 .and(agenda.startDate.loe(LocalDate.now())) // 이미 시작됨
                                 .and(agenda.endDate.goe(LocalDate.now())) // 아직 종료되지 않음
+                                .and(agenda.isEnd.not())
                                 .and(gtEndDateOrEqEndDateAndGtId(endDate, agendaId)) // 무한 스크롤
                 )
                 .orderBy(agenda.endDate.asc(), agenda.id.asc()) // 종료 날짜 오름차순 정렬
@@ -197,7 +198,7 @@ public class CustomAgendaRepositoryImpl implements CustomAgendaRepository {
                 .where(
                         agenda.university.id.eq(universityId)
                                 .and(agenda.endDate.lt(LocalDate.now())) // 종료된 상태
-                                .and(agenda.isEnd)
+                                .or(agenda.isEnd)
                                 .and(ltEndDateOrEqEndDateAndGtId(endDate, agendaId)) // 무한 스크롤
                 )
                 .orderBy(agenda.endDate.desc(), agenda.id.asc()) // 종료 날짜 내림차순 정렬

--- a/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaValidService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/agenda/service/AgendaValidService.java
@@ -21,7 +21,7 @@ public class AgendaValidService {
         if (agenda.getStartDate().isAfter(LocalDate.now()))
             throw new AgendaException(ErrorCode.AGENDA_NOT_STARTED);
 
-        if (agenda.getEndDate().isBefore(LocalDate.now()))
+        if (agenda.getEndDate().isBefore(LocalDate.now()) || agenda.isEnd())
             throw new AgendaException(ErrorCode.AGENDA_CLOSED);
     }
 

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AdminAgendaWebSocketTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AdminAgendaWebSocketTest.java
@@ -1,0 +1,256 @@
+package com.bungeobbang.backend.chat;
+
+import com.bungeobbang.backend.admin.domain.Admin;
+import com.bungeobbang.backend.admin.domain.repository.AdminRepository;
+import com.bungeobbang.backend.agenda.domain.Agenda;
+import com.bungeobbang.backend.agenda.domain.AgendaChat;
+import com.bungeobbang.backend.agenda.domain.AgendaImage;
+import com.bungeobbang.backend.agenda.domain.repository.AgendaRepository;
+import com.bungeobbang.backend.agenda.domain.repository.MemberAgendaChatRepository;
+import com.bungeobbang.backend.auth.JwtProvider;
+import com.bungeobbang.backend.auth.domain.Authority;
+import com.bungeobbang.backend.auth.domain.repository.UuidRepository;
+import com.bungeobbang.backend.chat.event.common.AdminWebsocketMessage;
+import com.bungeobbang.backend.chat.type.RoomType;
+import com.bungeobbang.backend.chat.type.SocketEventType;
+import com.bungeobbang.backend.common.exception.ErrorCode;
+import com.bungeobbang.backend.member.domain.Member;
+import com.bungeobbang.backend.member.domain.ProviderType;
+import com.bungeobbang.backend.member.domain.repository.MemberRepository;
+import com.bungeobbang.backend.member.dto.response.MemberTokens;
+import com.bungeobbang.backend.university.domain.University;
+import com.bungeobbang.backend.university.domain.repository.UniversityRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.bungeobbang.backend.common.type.CategoryType.ACADEMICS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AdminAgendaWebSocketTest {
+    private static WebSocketSession session;
+    @LocalServerPort
+    int port;
+    CountDownLatch latch;
+    AtomicReference<String> receivedMessage;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private UuidRepository uuidRepository;
+    @Autowired
+    private UniversityRepository universityRepository;
+    @Autowired
+    private AdminRepository adminRepository;
+    @Autowired
+    private AgendaRepository agendaRepository;
+    @Autowired
+    private MemberAgendaChatRepository memberAgendaChatRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+    private Agenda CLOSED_AGENDA;
+    private Agenda ACTIVE_AGENDA;
+    private Agenda UPCOMING_AGENDA;
+    private Member MEMBER;
+    private Admin ADMIN;
+
+
+    @BeforeEach
+    void shouldConnectToWebSocket() throws ExecutionException, InterruptedException, TimeoutException {
+        agendaRepository.deleteAll();
+        adminRepository.deleteAll();
+        memberRepository.deleteAll();
+        universityRepository.deleteAll();
+
+
+        final University university = universityRepository.save(new University(null, "네이버대학교", "naver.com"));
+        ADMIN = adminRepository.save(new Admin(null, "login", "password", "name", university));
+        CLOSED_AGENDA = agendaRepository.save(Agenda.builder()
+                .admin(ADMIN)
+                .title("Naver")
+                .content("Naver")
+                .university(university)
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().minusDays(5))
+                .categoryType(ACADEMICS)
+                .images(List.of(new AgendaImage(1L, null, "image1")))
+                .build());
+        UPCOMING_AGENDA = agendaRepository.save(Agenda.builder()
+                .admin(ADMIN)
+                .title("Naver")
+                .content("Naver")
+                .university(university)
+                .startDate(LocalDate.now().plusDays(10))
+                .endDate(LocalDate.now().plusDays(5))
+                .categoryType(ACADEMICS)
+                .images(List.of(new AgendaImage(1L, null, "image1")))
+                .build());
+        ACTIVE_AGENDA = agendaRepository.save(Agenda.builder()
+                .admin(ADMIN)
+                .title("Naver")
+                .content("Naver")
+                .university(university)
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().plusDays(5))
+                .categoryType(ACADEMICS)
+                .images(List.of(new AgendaImage(1L, null, "image1")))
+                .build());
+        MEMBER = memberRepository.save(Member.builder().provider(ProviderType.KAKAO).email("email").loginId("1").university(university).build());
+        final String uuid = UUID.randomUUID().toString();
+        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(ADMIN.getId()), Authority.ADMIN, uuid);
+        uuidRepository.save(Authority.ADMIN, uuid, String.valueOf(ADMIN.getId()));
+        StandardWebSocketClient client = new StandardWebSocketClient();
+
+        if (session != null && session.isOpen()) {
+            System.out.println("Reusing existing WebSocket session: " + session.getId());
+            return;
+        }
+
+        String url = "ws://localhost:" + port + "/admins";
+
+        WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+        headers.add("Sec-WebSocket-Protocol", memberTokens.accessToken());
+
+        latch = new CountDownLatch(1);
+        receivedMessage = new AtomicReference<>();
+        AdminWebSocketClientHandler clientHandler = new AdminWebSocketClientHandler(latch, receivedMessage);
+        session = client.execute(
+                clientHandler,
+                headers,
+                URI.create(url)
+        ).get(5, TimeUnit.SECONDS);
+
+
+        assertThat(session.isOpen()).isTrue();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("아직 진행 전인 답해요에 채팅을 보내면 에러 이벤트를 응답한다.")
+    void testSendChatMessageAndVerifyStorage() throws Exception {
+        // given
+        AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, UPCOMING_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
+                List.of("image1", "image2"), ADMIN.getId(), null, 0
+        );
+        String messageJson = objectMapper.writeValueAsString(payload);
+        // when
+        session.sendMessage(new TextMessage(messageJson));
+
+        // then
+        boolean messageReceived = latch.await(5, TimeUnit.SECONDS);
+        assertThat(messageReceived).isTrue();
+        final String message = receivedMessage.get();
+        final AdminWebsocketMessage actual = objectMapper.readValue(message, AdminWebsocketMessage.class);
+        assertThat(actual)
+                .extracting("event", "message", "code")
+                .containsExactly(SocketEventType.ERROR, ErrorCode.AGENDA_NOT_STARTED.getMessage(), ErrorCode.AGENDA_NOT_STARTED.getCode());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("진행종료된 답해요에 채팅을 보내면 에러를 응답한다.")
+    void sendChatToClosedAgenda() throws IOException, InterruptedException {
+        // given
+        AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, CLOSED_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
+                List.of("image1", "image2"), ADMIN.getId(), null, 0
+        );
+        String messageJson = objectMapper.writeValueAsString(payload);
+        // when
+        session.sendMessage(new TextMessage(messageJson));
+        // then
+        boolean messageReceived = latch.await(5, TimeUnit.SECONDS);
+        assertThat(messageReceived).isTrue();
+        final String message = receivedMessage.get();
+        final AdminWebsocketMessage actual = objectMapper.readValue(message, AdminWebsocketMessage.class);
+        assertThat(actual)
+                .extracting("event", "message", "code")
+                .containsExactly(SocketEventType.ERROR, ErrorCode.AGENDA_CLOSED.getMessage(), ErrorCode.AGENDA_CLOSED.getCode());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("진행 중인 답해요에 채팅을 보내면 해당 채팅을 응답받고, 채팅이 저장된다.")
+    void sendChatToActiveAgenda() throws Exception {
+        // given
+        AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
+                List.of("image1", "image2"), ADMIN.getId(), null, 0
+        );
+        String messageJson = objectMapper.writeValueAsString(payload);
+        // when
+        session.sendMessage(new TextMessage(messageJson));
+        //then
+        boolean messageReceived = latch.await(5, TimeUnit.SECONDS);
+        assertThat(messageReceived).isTrue();
+        final String message = receivedMessage.get();
+        final AdminWebsocketMessage actual = objectMapper.readValue(message, AdminWebsocketMessage.class);
+        assertThat(actual)
+                .extracting("event", "message", "code")
+                .containsExactly(SocketEventType.CHAT, payload.message(), 0);
+
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    AgendaChat lastChat = memberAgendaChatRepository.findLastChat(ACTIVE_AGENDA.getId(), MEMBER.getId());
+                    Assertions.assertThat(lastChat)
+                            .isNotNull()
+                            .extracting("chat")
+                            .isEqualTo(payload.message());
+                });
+    }
+
+
+    @AfterEach
+    void teardown() throws Exception {
+        if (session != null && session.isOpen()) {
+            session.close();
+        }
+    }
+
+    public class AdminWebSocketClientHandler extends TextWebSocketHandler {
+        private final CountDownLatch latch;
+        private final AtomicReference<String> receivedMessage;
+
+        public AdminWebSocketClientHandler(CountDownLatch latch, AtomicReference<String> receivedMessage) {
+            this.latch = latch;
+            this.receivedMessage = receivedMessage;
+        }
+
+        @Override
+        protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+            receivedMessage.set(message.getPayload()); // 응답 메시지 저장
+            System.out.println("🆕들어오긴하나,,,");
+            latch.countDown(); // 응답을 받았으므로 countDown()
+        }
+
+        @Override
+        public void afterConnectionEstablished(WebSocketSession session) {
+            System.out.println("✅ WebSocket 연결 성공: " + session.getId());
+        }
+    }
+}

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
@@ -1,0 +1,195 @@
+package com.bungeobbang.backend.chat;
+
+import com.bungeobbang.backend.auth.JwtProvider;
+import com.bungeobbang.backend.auth.domain.Authority;
+import com.bungeobbang.backend.auth.domain.repository.UuidRepository;
+import com.bungeobbang.backend.chat.event.common.MemberWebsocketMessage;
+import com.bungeobbang.backend.chat.type.RoomType;
+import com.bungeobbang.backend.chat.type.SocketEventType;
+import com.bungeobbang.backend.member.dto.response.MemberTokens;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = "/data/member.sql")
+public class AgendaWebSocketConcurrencyTest {
+    private static WebSocketSession session;
+    private final Long ACTIVE_AGENDA_ID = 1L;
+    private final int memberCount = 100;
+    @LocalServerPort
+    int port;
+    CountDownLatch latch;
+    AtomicInteger receivedMessages;
+    Map<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private UuidRepository uuidRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void connectMember() throws ExecutionException, InterruptedException, TimeoutException {
+        for (int i = 1; i <= memberCount; i++) {
+            final String uuid = UUID.randomUUID().toString();
+            final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(i), Authority.MEMBER, uuid);
+            uuidRepository.save(Authority.MEMBER, uuid, String.valueOf(i));
+            StandardWebSocketClient client = new StandardWebSocketClient();
+            String url = "ws://localhost:" + port + "/students";
+
+            WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+            headers.add("Sec-WebSocket-Protocol", memberTokens.accessToken());
+            final WebSocketSession webSocketSession = client.execute(
+                    new WebSocketHandler() {
+                        @Override
+                        public void afterConnectionEstablished(WebSocketSession session) {
+
+                        }
+
+                        @Override
+                        public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+
+                        }
+
+                        @Override
+                        public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+
+                        }
+
+                        @Override
+                        public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus) throws Exception {
+
+                        }
+
+                        @Override
+                        public boolean supportsPartialMessages() {
+                            return false;
+                        }
+                    },
+                    headers,
+                    URI.create(url)
+            ).get(5, TimeUnit.SECONDS);
+            sessions.put((long) i, webSocketSession);
+        }
+        Assertions.assertThat(sessions).hasSize(memberCount);
+    }
+
+    @Test
+    @DisplayName("학생이 동시에 n개의 메세지를 보내면 학생회는 n개 모두 수신받아야한다.")
+    void sendChats() throws Exception {
+        // given
+        StandardWebSocketClient client = new StandardWebSocketClient();
+        String url = "ws://localhost:" + port + "/admins";
+        final String uuid = UUID.randomUUID().toString();
+        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(1), Authority.ADMIN, uuid);
+        uuidRepository.save(Authority.ADMIN, uuid, String.valueOf(1));
+        WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+        headers.add("Sec-WebSocket-Protocol", memberTokens.accessToken());
+
+        ExecutorService executorService = Executors.newFixedThreadPool(memberCount);
+        latch = new CountDownLatch(memberCount);
+        receivedMessages = new AtomicInteger(0);
+        WebSocketClientHandler clientHandler = new WebSocketClientHandler(latch, receivedMessages);
+        session = client.execute(
+                clientHandler,
+                headers,
+                URI.create(url)
+        ).get(5, TimeUnit.SECONDS);
+        assertThat(session.isOpen()).isTrue();
+
+        // when
+        for (int i = 1; i <= memberCount; i++) {
+            long memberId = i;
+            executorService.execute(() -> {
+                try {
+
+                    MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA_ID, "채팅",
+                            null, memberId, null, 0
+                    );
+                    String messageJson = objectMapper.writeValueAsString(payload);
+                    sessions.get(memberId).sendMessage(new TextMessage(messageJson));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        // then
+        boolean completed = latch.await(10, TimeUnit.SECONDS);
+        assertThat(receivedMessages.get()).isEqualTo(memberCount);
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        if (session != null && session.isOpen()) {
+            session.close();
+        }
+    }
+
+    public class WebSocketClientHandler extends TextWebSocketHandler {
+        private final CountDownLatch latch;
+        private final AtomicInteger receivedMessage;
+
+        public WebSocketClientHandler(CountDownLatch latch, AtomicInteger receivedMessage) {
+            this.latch = latch;
+            this.receivedMessage = receivedMessage;
+        }
+
+        @Override
+        protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+            receivedMessage.incrementAndGet();
+            latch.countDown();
+        }
+
+        @Override
+        public void afterConnectionEstablished(WebSocketSession session) {
+            System.out.println("✅ WebSocket 연결 성공: " + session.getId());
+        }
+    }
+
+
+    public class AdminWebSocketClientHandler extends TextWebSocketHandler {
+        private final CountDownLatch latch;
+        private final AtomicReference<String> receivedMessage;
+
+        public AdminWebSocketClientHandler(CountDownLatch latch, AtomicReference<String> receivedMessage) {
+            this.latch = latch;
+            this.receivedMessage = receivedMessage;
+        }
+
+        @Override
+        protected void handleTextMessage(WebSocketSession session, TextMessage message) {
+            receivedMessage.set(message.getPayload()); // 응답 메시지 저장
+            latch.countDown(); // 응답을 받았으므로 countDown()
+        }
+
+        @Override
+        public void afterConnectionEstablished(WebSocketSession session) {
+            System.out.println("✅ WebSocket 연결 성공: " + session.getId());
+        }
+    }
+}

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AgendaWebSocketConcurrencyTest {
     private static WebSocketSession session;
     private final Long ACTIVE_AGENDA_ID = 1L;
+    @Value("${test.member.count:100}")
     private final int memberCount = 100;
     @LocalServerPort
     int port;
@@ -97,7 +99,7 @@ public class AgendaWebSocketConcurrencyTest {
     }
 
     @Test
-    @DisplayName("학생이 동시에 n개의 메세지를 보내면 학생회는 n개 모두 수신받아야한다.")
+    @DisplayName("학생 n명이 동시에 메세지를 보내면 학생회는 n개 모두 수신받아야한다.")
     void sendChats() throws Exception {
         // given
         StandardWebSocketClient client = new StandardWebSocketClient();

--- a/backend/src/test/resources/data/member.sql
+++ b/backend/src/test/resources/data/member.sql
@@ -1,0 +1,37 @@
+delete
+from agenda
+where id > 0;
+delete
+from member
+where id > 0;
+delete
+from admin
+where id > 0;
+delete
+from university
+where id > 0;
+
+INSERT INTO university (id, name, domain, created_at, modified_at)
+VALUES (1, '네이버대학교', 'naver.com', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO admin (id, login_id, name, password, university_id, created_at, modified_at)
+VALUES (1, 'admin', '관리자', '$2a$10$8O1QVz06uF47OVPa.lpZxO5ErUzG1OShT/1rb.gET4cZ4IjxEnlU.', 1, CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP);
+
+
+INSERT INTO agenda (id, university_id, admin_id, title, start_date, end_date, content, is_end, participant_count,
+                    category_type, created_at, modified_at)
+VALUES (1, 1, 1, '학생 정보 보안 강화', DATEADD(DAY, -15, CURRENT_DATE), DATEADD(DAY, 20, CURRENT_DATE), '학생 정보 보안 강화에 대한 논의.',
+        false,
+        203, 'IT', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO member (id, login_id, email, provider, university_id, created_at, modified_at)
+SELECT X,
+       'login_id_' || X,
+       'member' || X || '@naver.com',
+       'KAKAO',
+       1,
+       CURRENT_TIMESTAMP,
+       CURRENT_TIMESTAMP
+FROM SYSTEM_RANGE(1, 100);
+


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 즉시 종료된 답해요 진행 중으로 가져오는 버그 수정
- 


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- customAgendaRepository isEnd 확인 추가
- 


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 웹소켓 동시성테스트
    - 학생 100명이 동시에 채팅을 보내면 학생회가 100개의 메시지를 모두 수신할 수 있는지 확인하는 테스트 작성하였습니다.
    - 로컬에서는 1000개도 수신하는데 test_server에 올려서 실행해보니 1000개까지 웹소켓 연결이 안되더라고요,,,(100개는 됨)
    - 원인이 뭘지,,, 같이 얘기해보면 좋을거같슴다ㅏ
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #333 
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Administrators can now access detailed agenda statistics with monthly/yearly breakdowns and category insights.
	- Chat interactions have been enhanced with smoother scrolling and improved message handling.
	- Extended session durations offer longer token validity for a more seamless user experience.

- **Bug Fixes**
	- Agenda filtering has been refined to more accurately distinguish between active and closed agendas.
	- Error feedback now includes detailed codes for clearer communication of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->