### PR TITLE
[FIX/FE/258] 채팅이 하나밖에 없는데 소켓 메시지가 왔을 때 렌더링 안 되는 문제 

### DIFF
--- a/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
@@ -309,12 +309,18 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
       }
     };
 
-    const { setTriggerUpItem, setTriggerDownItem, getHasDownMore, setHasUpMore, setHasDownMore } =
-      useInfiniteScroll({
-        initialFetch: getInitialChatData,
-        fetchUpMore: getMoreUpChatData,
-        fetchDownMore: getMoreDownChatData,
-      });
+    const {
+      setTriggerUpItem,
+      setTriggerDownItem,
+      getHasUpMore,
+      getHasDownMore,
+      setHasUpMore,
+      setHasDownMore,
+    } = useInfiniteScroll({
+      initialFetch: getInitialChatData,
+      fetchUpMore: getMoreUpChatData,
+      fetchDownMore: getMoreDownChatData,
+    });
 
     useLayoutEffect(() => {
       if (!elementRef.current || chatData.length === 0) return;
@@ -417,7 +423,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
         )}
         <S.ChatList ref={elementRef}>
           {chatData.map((chat, chatIndex) => {
-            const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS;
+            const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS && getHasUpMore();
             const isDownTriggerItem = chatIndex === chatData.length - LAST_REMAIN_ITEMS;
 
             if (chat.type === ChatType.RECEIVE) {

--- a/frontend/src/domains/admin/pages/agenda/index.tsx
+++ b/frontend/src/domains/admin/pages/agenda/index.tsx
@@ -154,7 +154,7 @@ const AgendaPage: React.FC = () => {
       const closed = await api.get('/admin/agendas', { params: params });
 
       const newRooms = closed.data.map((res: ServerData) =>
-        mapResponseToChatRoomListCardData(res, status),
+        mapResponseToChatRoomListCardData(res, 'CLOSED'),
       );
 
       setTabContents((prev) => ({
@@ -183,7 +183,9 @@ const AgendaPage: React.FC = () => {
       };
       const closed = await api.get('/admin/agendas', { params: params });
 
-      const newRooms = closed.data.map(mapResponseToChatRoomListCardData);
+      const newRooms = closed.data.map((res: ServerData) =>
+        mapResponseToChatRoomListCardData(res, 'CLOSED'),
+      );
 
       setTabContents((prev) => ({
         ...prev,

--- a/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
@@ -56,7 +56,6 @@ const OpinionChatPage = () => {
   const handleMessageReceive = useCallback(
     (message: ChatMessage) => {
       if (message.roomType === 'OPINION' && message.opinionId === Number(roomId)) {
-        console.log('message1213', getHasDownMore());
         // const newChat = {
         //   type: message.adminId === Number(memberId) ? ChatType.SEND : ChatType.RECEIVE,
         //   message: message.message,
@@ -278,12 +277,18 @@ const OpinionChatPage = () => {
     }
   };
 
-  const { setTriggerUpItem, setTriggerDownItem, getHasDownMore, setHasUpMore, setHasDownMore } =
-    useInfiniteScroll({
-      initialFetch: getInitialChatData,
-      fetchUpMore: getMoreUpChatData,
-      fetchDownMore: getMoreDownChatData,
-    });
+  const {
+    setTriggerUpItem,
+    setTriggerDownItem,
+    getHasUpMore,
+    getHasDownMore,
+    setHasUpMore,
+    setHasDownMore,
+  } = useInfiniteScroll({
+    initialFetch: getInitialChatData,
+    fetchUpMore: getMoreUpChatData,
+    fetchDownMore: getMoreDownChatData,
+  });
 
   useLayoutEffect(() => {
     if (!elementRef.current || chatData.length === 0) return;
@@ -358,7 +363,7 @@ const OpinionChatPage = () => {
 
       <S.ChatList ref={elementRef}>
         {chatData.map((chat, index) => {
-          const isUpTriggerItem = index === FIRST_REMAIN_ITEMS;
+          const isUpTriggerItem = index === FIRST_REMAIN_ITEMS && getHasUpMore();
           const isDownTriggerItem = index === chatData.length - LAST_REMAIN_ITEMS;
 
           if (chat.type === ChatType.RECEIVE) {

--- a/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
@@ -293,12 +293,18 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
       }
     };
 
-    const { setTriggerUpItem, setTriggerDownItem, getHasDownMore, setHasUpMore, setHasDownMore } =
-      useInfiniteScroll({
-        initialFetch: getInitialChatData,
-        fetchUpMore: getMoreUpChatData,
-        fetchDownMore: getMoreDownChatData,
-      });
+    const {
+      setTriggerUpItem,
+      setTriggerDownItem,
+      getHasUpMore,
+      getHasDownMore,
+      setHasUpMore,
+      setHasDownMore,
+    } = useInfiniteScroll({
+      initialFetch: getInitialChatData,
+      fetchUpMore: getMoreUpChatData,
+      fetchDownMore: getMoreDownChatData,
+    });
 
     useLayoutEffect(() => {
       if (!elementRef.current || chatData.length === 0) return;
@@ -377,7 +383,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
         />
         <S.ChatList ref={elementRef}>
           {chatData.map((chat, chatIndex) => {
-            const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS;
+            const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS && getHasUpMore();
             const isDownTriggerItem = chatIndex === chatData.length - LAST_REMAIN_ITEMS;
 
             if (chat.type === ChatType.RECEIVE) {

--- a/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
@@ -72,10 +72,10 @@ const OpinionChatPage = () => {
           images: message.images || [],
           createdAt: message.createdAt,
         };
-        if (newChat.type === ChatType.RECEIVE) {
-          setIsRemindEnabled(false);
-          setIsReminded(false);
-        }
+        // if (newChat.type === ChatType.RECEIVE) {
+        //   setIsRemindEnabled(false);
+        //   setIsReminded(false);
+        // }
         if (message.memberId === Number(memberId)) {
           getReloadChatDataFromRecent();
         } else {

--- a/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
@@ -72,10 +72,10 @@ const OpinionChatPage = () => {
           images: message.images || [],
           createdAt: message.createdAt,
         };
-        // if (newChat.type === ChatType.RECEIVE) {
-        //   setIsRemindEnabled(false);
-        //   setIsReminded(false);
-        // }
+        if (newChat.type === ChatType.RECEIVE) {
+          setIsRemindEnabled(false);
+          setIsReminded(false);
+        }
         if (message.memberId === Number(memberId)) {
           getReloadChatDataFromRecent();
         } else {
@@ -159,7 +159,6 @@ const OpinionChatPage = () => {
   const isInitialRecentLoading = useRef<boolean>(false);
   const isUpDirection = useRef<boolean>(false);
   const isDownDirection = useRef<boolean>(false);
-  // const isLiveReceive = useRef<boolean>(false);
 
   const isUpOverflow = useRef<boolean>(false);
   const isDownOverflow = useRef<boolean>(false);
@@ -229,7 +228,7 @@ const OpinionChatPage = () => {
 
       const formattedData = formatChatData(response.data, false);
 
-      setHasDownMore(false);
+      // setHasDownMore(false);
       setChatData(formattedData);
       enterResponse.data.isReminded && setIsReminded(true);
       setChatRoomInfo({
@@ -253,7 +252,7 @@ const OpinionChatPage = () => {
 
       const formattedData = formatChatData(response.data, false);
 
-      setHasDownMore(false);
+      // setHasDownMore(false);
       setChatData(formattedData);
     } catch (error) {
       console.error('fail to get chat data', error);
@@ -316,15 +315,21 @@ const OpinionChatPage = () => {
     }
   };
 
-  const { setTriggerUpItem, setTriggerDownItem, getHasDownMore, setHasUpMore, setHasDownMore } =
-    useInfiniteScroll({
-      initialFetch: getInitialChatData,
-      fetchUpMore: getMoreUpChatData,
-      fetchDownMore: getMoreDownChatData,
-    });
+  const {
+    setTriggerUpItem,
+    setTriggerDownItem,
+    getHasUpMore,
+    getHasDownMore,
+    setHasUpMore,
+    setHasDownMore,
+  } = useInfiniteScroll({
+    initialFetch: getInitialChatData,
+    fetchUpMore: getMoreUpChatData,
+    fetchDownMore: getMoreDownChatData,
+  });
 
   useLayoutEffect(() => {
-    if (!elementRef.current) return;
+    if (!elementRef.current || chatData.length === 0) return;
     console.log('getchasdata', chatData);
 
     if (isInitialTopLoading.current === true) {
@@ -341,6 +346,7 @@ const OpinionChatPage = () => {
     }
 
     if (isUpDirection.current === true) {
+      console.log('up!');
       if (isUpOverflow.current === true) {
         restoreScrollTopFromUp();
         isUpOverflow.current = false;
@@ -363,6 +369,7 @@ const OpinionChatPage = () => {
     }
 
     if (isDownDirection.current) {
+      console.log('down!');
       if (isDownOverflow.current === true) {
         // console.log("down 호출");
         restoreScrollTopFromDown();
@@ -401,7 +408,7 @@ const OpinionChatPage = () => {
       />
       <S.ChatList ref={elementRef}>
         {chatData.map((chat, chatIndex) => {
-          const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS;
+          const isUpTriggerItem = chatIndex === FIRST_REMAIN_ITEMS && getHasUpMore();
           const isDownTriggerItem = chatIndex === chatData.length - LAST_REMAIN_ITEMS;
 
           if (chat.type === ChatType.RECEIVE) {


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 채팅이 하나밖에 없는데 소켓 메시지가 왔을 때 렌더링 안 되는 문제 해결
   - up, down 둘 중 하나만 observe되도록 해놨는데 up이 없을 경우 계속 up obeserver로 등록이 되어서 down observer는 등록되지 못함
   - 소켓 메시지가 오면 getHasDownMore를 확인하는데 등록이 되지 못해서 초기값 true로 유지
   - 아래로 더 요청할 메시지가 있는 줄 알고 최신 데이터로 렌더링하지 않음
- 


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 학생회 답해요 채팅방에서 종료 채팅방일 때 입력 막기
- 


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
