### PR TITLE
[FIX/FE/258] 무한 스크롤 소켓 메시지 왔을 때 gethasmore, gethasdown 풀어주기

### DIFF
--- a/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
@@ -99,7 +99,9 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
           } else {
             if (!getHasDownMore() && isWatchingBottom()) {
               getReloadChatDataFromRecent();
+              return;
             }
+            setHasDownMore(true);
             setToastMeesage('새로운 채팅이 도착했습니다.');
           }
         }

--- a/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
@@ -247,10 +247,11 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
           },
         });
 
-        console.log('responsesseee', response);
+        console.log('reload responsesseee', response);
 
         const formattedData = formatChatData(response.data, true);
 
+        setHasUpMore(true);
         setHasDownMore(false);
         setChatData(formattedData);
       } catch (error) {

--- a/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
@@ -68,7 +68,7 @@ const OpinionChatPage = () => {
         // };
 
         if (message.adminId === Number(memberId)) {
-          getInitialChatDataFromRecent();
+          getReloadChatDataFromRecent();
         } else {
           if (!getHasDownMore() && isWatchingBottom()) {
             getReloadChatDataFromRecent();
@@ -209,11 +209,12 @@ const OpinionChatPage = () => {
         },
       });
 
-      console.log('responsesseee', response);
+      console.log('reload responsesseee', response);
 
       const formattedData = formatChatData(response.data, true);
 
-      // setHasDownMore(false);
+      setHasUpMore(true);
+      setHasDownMore(false);
       setChatData(formattedData);
       // enterResponse.data.isReminded && setIsReminded(true);
     } catch (error) {

--- a/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
@@ -72,7 +72,9 @@ const OpinionChatPage = () => {
         } else {
           if (!getHasDownMore() && isWatchingBottom()) {
             getReloadChatDataFromRecent();
+            return;
           }
+          setHasDownMore(true);
           setToastMeesage('새로운 채팅이 도착했습니다.');
         }
       }

--- a/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
@@ -108,7 +108,9 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
           } else {
             if (!getHasDownMore() && isWatchingBottom()) {
               getReloadChatDataFromRecent();
+              return;
             }
+            setHasDownMore(true);
             setToastMeesage('새로운 채팅이 도착했습니다.');
           }
         }

--- a/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
@@ -240,6 +240,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
         const formattedData = formatChatData(response.data, false);
 
+        setHasUpMore(true);
         setHasDownMore(false);
         setChatData(formattedData);
       } catch (error) {

--- a/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
@@ -81,7 +81,9 @@ const OpinionChatPage = () => {
         } else {
           if (!getHasDownMore() && isWatchingBottom()) {
             getReloadChatDataFromRecent();
+            return;
           }
+          setHasDownMore(true);
           setToastMeesage('새로운 채팅이 도착했습니다.');
         }
       }

--- a/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
@@ -254,7 +254,8 @@ const OpinionChatPage = () => {
 
       const formattedData = formatChatData(response.data, false);
 
-      // setHasDownMore(false);
+      setHasUpMore(true);
+      setHasDownMore(false);
       setChatData(formattedData);
     } catch (error) {
       console.error('fail to get chat data', error);


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 이미 다 채팅을 보고 나서 getHasDownMore가 false가 되었을 때 소켓 메시지가 오면 true로 풀어줘야함
- getReloadChatDataFromRecent 에서 hasUpMore는 true로 hasDownMore는 false로 막아줘야함


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 
- 


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
