### PR TITLE
[Feat/BE/#393] opinion 생성 시 웹소켓 이벤트 전송

### DIFF
--- a/backend/src/main/java/com/bungeobbang/backend/admin/service/AdminLoginService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/admin/service/AdminLoginService.java
@@ -42,7 +42,8 @@ public class AdminLoginService {
         MemberTokens memberTokens = jwtProvider.generateLoginToken(
                 admin.getId().toString(),
                 ADMIN,
-                uuid
+                uuid,
+                String.valueOf(admin.getUniversity().getId())
         );
         refreshTokenRepository.saveRefreshToken(ADMIN, String.valueOf(admin.getId()), memberTokens.refreshToken());
 

--- a/backend/src/main/java/com/bungeobbang/backend/auth/Claim.java
+++ b/backend/src/main/java/com/bungeobbang/backend/auth/Claim.java
@@ -3,6 +3,7 @@ package com.bungeobbang.backend.auth;
 public enum Claim {
     ROLE("role"),
     UUID("uuid"),
+    UNIVERSITY("universityId"),
     ;
     private final String name;
 

--- a/backend/src/main/java/com/bungeobbang/backend/auth/JwtProvider.java
+++ b/backend/src/main/java/com/bungeobbang/backend/auth/JwtProvider.java
@@ -34,8 +34,9 @@ public class JwtProvider {
 
     public MemberTokens generateLoginToken(final String subject,
                                            final Authority authority,
-                                           final String uuid) {
-        final String accessToken = createTokenWithRole(subject, authority, uuid, accessExpirationTime);
+                                           final String uuid,
+                                           String universityId) {
+        final String accessToken = createTokenWithRole(subject, authority, uuid, universityId, accessExpirationTime);
         final String refreshToken = createToken(EMPTY_SUBJECT, refreshExpirationTime);
         return new MemberTokens(accessToken, refreshToken);
     }
@@ -58,6 +59,24 @@ public class JwtProvider {
                 .setSubject(subject)
                 .claim(Claim.ROLE.toString(), authority)
                 .claim(Claim.UUID.toString(), uuid)
+                .setIssuedAt(now)
+                .setExpiration(expiresAt)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String createTokenWithRole(final String subject, final Authority authority,
+                                       final String uuid,
+                                       final String universityId, final Long validityInMilliseconds) {
+        final Date now = new Date();
+        final Date expiresAt = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setSubject(subject)
+                .claim(Claim.ROLE.toString(), authority)
+                .claim(Claim.UUID.toString(), uuid)
+                .claim(Claim.UNIVERSITY.toString(), universityId)
                 .setIssuedAt(now)
                 .setExpiration(expiresAt)
                 .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/backend/src/main/java/com/bungeobbang/backend/chat/event/common/AdminWebsocketMessage.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/event/common/AdminWebsocketMessage.java
@@ -24,16 +24,18 @@ public record AdminWebsocketMessage(
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Long adminId,
         @JsonInclude(JsonInclude.Include.NON_NULL)
+        Long universityId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         int code
 ) {
     public AdminWebsocketMessage(SocketEventType event, String message, int errorCode) {
-        this(null, event, null, null, message, null, null, null, errorCode);
+        this(null, event, null, null, message, null, null, null, null, errorCode);
     }
 
-    public static AdminWebsocketMessage createResponse(AdminWebsocketMessage request) {
+    public static AdminWebsocketMessage createResponse(AdminWebsocketMessage request, Long universityId) {
         return new AdminWebsocketMessage(
                 request.roomType,
                 request.event,
@@ -42,6 +44,7 @@ public record AdminWebsocketMessage(
                 request.message,
                 request.images,
                 request.adminId,
+                universityId,
                 LocalDateTime.now(),
                 0
         );

--- a/backend/src/main/java/com/bungeobbang/backend/chat/event/common/MemberWebsocketMessage.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/event/common/MemberWebsocketMessage.java
@@ -24,16 +24,18 @@ public record MemberWebsocketMessage(
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Long memberId,
         @JsonInclude(JsonInclude.Include.NON_NULL)
+        Long universityId,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         int code
 ) {
     public MemberWebsocketMessage(SocketEventType event, String message, int code) {
-        this(null, event, null, null, message, null, null, null, code);
+        this(null, event, null, null, message, null, null, null, null, code);
     }
 
-    public static MemberWebsocketMessage createResponse(MemberWebsocketMessage request) {
+    public static MemberWebsocketMessage createResponse(MemberWebsocketMessage request, Long universityId) {
         return new MemberWebsocketMessage(
                 request.roomType,
                 request.event,
@@ -42,6 +44,7 @@ public record MemberWebsocketMessage(
                 request.message,
                 request.images,
                 request.memberId,
+                universityId,
                 LocalDateTime.now(),
                 0
         );

--- a/backend/src/main/java/com/bungeobbang/backend/chat/event/opinion/OpinionCreationEvent.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/event/opinion/OpinionCreationEvent.java
@@ -1,0 +1,17 @@
+package com.bungeobbang.backend.chat.event.opinion;
+
+import com.bungeobbang.backend.chat.type.SocketEventType;
+import com.bungeobbang.backend.common.type.CategoryType;
+import com.bungeobbang.backend.opinion.domain.OpinionType;
+
+import java.time.LocalDateTime;
+
+public record OpinionCreationEvent(
+        SocketEventType eventType,
+        CategoryType categoryType,
+        OpinionType opinionType,
+        Long opinionId,
+        String message,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/java/com/bungeobbang/backend/chat/handler/AdminWebSocketChatHandler.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/handler/AdminWebSocketChatHandler.java
@@ -63,8 +63,9 @@ public class AdminWebSocketChatHandler extends TextWebSocketHandler {
                 session.sendMessage(new TextMessage("PONG"));
                 return;
             }
+            final Long universityId = Long.valueOf(jwtProvider.getClaim(accessToken, Claim.UNIVERSITY));
             // createdAt 생성하여 requestContainsCreatedAt 객체 생성
-            final AdminWebsocketMessage requestContainsCreatedAt = AdminWebsocketMessage.createResponse(request);
+            final AdminWebsocketMessage requestContainsCreatedAt = AdminWebsocketMessage.createResponse(request, universityId);
 
 
             switch (request.roomType()) {

--- a/backend/src/main/java/com/bungeobbang/backend/chat/handler/MemberWebSocketChatHandler.java
+++ b/backend/src/main/java/com/bungeobbang/backend/chat/handler/MemberWebSocketChatHandler.java
@@ -63,7 +63,8 @@ public class MemberWebSocketChatHandler extends TextWebSocketHandler {
                 session.sendMessage(new TextMessage("PONG"));
                 return;
             }
-            final MemberWebsocketMessage requestContainsCreatedAt = MemberWebsocketMessage.createResponse(request);
+            final Long universityId = Long.valueOf(jwtProvider.getClaim(accessToken, Claim.UNIVERSITY));
+            final MemberWebsocketMessage requestContainsCreatedAt = MemberWebsocketMessage.createResponse(request, universityId);
 
             switch (request.roomType()) {
                 case AGENDA -> publisher.publishEvent(AgendaMemberEvent.from(session, requestContainsCreatedAt));

--- a/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/member/service/MemberService.java
@@ -56,7 +56,8 @@ public class MemberService {
         final MemberTokens memberTokens = jwtProvider.generateLoginToken(
                 memberId.toString(),
                 MEMBER,
-                uuid);
+                uuid,
+                String.valueOf(member.getUniversity().getId()));
         // refreshToken 저장
         saveRefreshToken(memberId, memberTokens.refreshToken());
 

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/service/OpinionRealTimeChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/service/OpinionRealTimeChatService.java
@@ -95,9 +95,7 @@ public class OpinionRealTimeChatService {
     public void disconnectAdmin(final AdminDisconnectEvent event) {
         Admin admin = adminRepository.findById(event.adminId())
                 .orElseThrow(() -> new AdminException(ErrorCode.INVALID_ADMIN));
-        opinionRepository.findAllByUniversityId(admin.getUniversity().getId())
-                .forEach(opinion ->
-                        messageQueueService.unsubscribe(event.session(), OPINION_PREFIX + opinion.getId()));
+        messageQueueService.unsubscribe(event.session(), OPINION_UNIV_PREFIX + admin.getUniversity().getId());
     }
 
     public void removeOpinionTopic(final Long opinionId) {

--- a/backend/src/main/java/com/bungeobbang/backend/opinion/service/OpinionRealTimeChatService.java
+++ b/backend/src/main/java/com/bungeobbang/backend/opinion/service/OpinionRealTimeChatService.java
@@ -3,6 +3,7 @@ package com.bungeobbang.backend.opinion.service;
 import com.bungeobbang.backend.admin.domain.Admin;
 import com.bungeobbang.backend.admin.domain.repository.AdminRepository;
 import com.bungeobbang.backend.chat.event.common.*;
+import com.bungeobbang.backend.chat.event.opinion.OpinionCreationEvent;
 import com.bungeobbang.backend.chat.service.MessageQueueService;
 import com.bungeobbang.backend.common.exception.AdminException;
 import com.bungeobbang.backend.common.exception.ErrorCode;
@@ -19,6 +20,7 @@ import org.springframework.web.socket.WebSocketSession;
 @RequiredArgsConstructor
 public class OpinionRealTimeChatService {
     private static final String OPINION_PREFIX = "O_";
+    private static final String OPINION_UNIV_PREFIX = "OU_";
     private final OpinionRepository opinionRepository;
     private final MessageQueueService messageQueueService;
     private final AdminRepository adminRepository;
@@ -36,14 +38,16 @@ public class OpinionRealTimeChatService {
         final Admin admin = adminRepository.findById(event.adminId())
                 .orElseThrow(() -> new AdminException(ErrorCode.INVALID_ADMIN));
         final Long universityId = admin.getUniversity().getId();
-        opinionRepository.findAllByUniversityId(universityId)
-                .forEach(opinion ->
-                        messageQueueService.subscribe(event.session(), OPINION_PREFIX + opinion.getId()));
+
+        messageQueueService.subscribe(event.session(), OPINION_UNIV_PREFIX + universityId);
     }
 
     public void sendMessageFromMember(final MemberWebsocketMessage event) {
         try {
             messageQueueService.publish(OPINION_PREFIX + event.opinionId(), objectMapper.writeValueAsString(event));
+
+            // 대학에다가 보낸다
+            messageQueueService.publish(OPINION_UNIV_PREFIX + event.universityId(), objectMapper.writeValueAsString(event));
         } catch (JsonProcessingException e) {
             throw new OpinionException(ErrorCode.JSON_PARSE_FAIL);
         }
@@ -51,6 +55,7 @@ public class OpinionRealTimeChatService {
 
     public void sendMessageFromAdmin(final AdminWebsocketMessage event) {
         try {
+            messageQueueService.publish(OPINION_UNIV_PREFIX + event.universityId(), objectMapper.writeValueAsString(event));
             messageQueueService.publish(OPINION_PREFIX + event.opinionId(), objectMapper.writeValueAsString(event));
         } catch (JsonProcessingException e) {
             throw new OpinionException(ErrorCode.JSON_PARSE_FAIL);
@@ -60,6 +65,14 @@ public class OpinionRealTimeChatService {
     public void validateExistOpinion(final Long opinionId) {
         opinionRepository.findById(opinionId)
                 .orElseThrow(() -> new OpinionException(ErrorCode.DELETED_OPINION));
+    }
+
+    public void sendOpinionStartToUniversity(Long universityId, OpinionCreationEvent event) {
+        try {
+            messageQueueService.publish(OPINION_UNIV_PREFIX + universityId, objectMapper.writeValueAsString(event));
+        } catch (JsonProcessingException e) {
+            throw new OpinionException(ErrorCode.JSON_PARSE_FAIL);
+        }
     }
 
     /*
@@ -81,7 +94,7 @@ public class OpinionRealTimeChatService {
     @EventListener
     public void disconnectAdmin(final AdminDisconnectEvent event) {
         Admin admin = adminRepository.findById(event.adminId())
-                        .orElseThrow(() -> new AdminException(ErrorCode.INVALID_ADMIN));
+                .orElseThrow(() -> new AdminException(ErrorCode.INVALID_ADMIN));
         opinionRepository.findAllByUniversityId(admin.getUniversity().getId())
                 .forEach(opinion ->
                         messageQueueService.unsubscribe(event.session(), OPINION_PREFIX + opinion.getId()));

--- a/backend/src/test/java/com/bungeobbang/backend/admin/service/AdminLoginServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/admin/service/AdminLoginServiceTest.java
@@ -87,7 +87,7 @@ class AdminLoginServiceTest {
                 .thenReturn(TRUE);
 
         final MemberTokens expected = new MemberTokens("access_token", "refresh_token");
-        when(jwtProvider.generateLoginToken(Mockito.anyString(), Mockito.any(Authority.class), Mockito.anyString()))
+        when(jwtProvider.generateLoginToken(Mockito.anyString(), Mockito.any(Authority.class), Mockito.anyString(), Mockito.anyString()))
                 .thenReturn(expected);
         doNothing().when(refreshTokenRepository).saveRefreshToken(Mockito.any(Authority.class), Mockito.anyString(), Mockito.anyString());
 

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AdminAgendaWebSocketTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AdminAgendaWebSocketTest.java
@@ -122,7 +122,7 @@ public class AdminAgendaWebSocketTest {
                 .build());
         MEMBER = memberRepository.save(Member.builder().provider(ProviderType.KAKAO).email("email").loginId("1").university(university).build());
         final String uuid = UUID.randomUUID().toString();
-        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(ADMIN.getId()), Authority.ADMIN, uuid);
+        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(ADMIN.getId()), Authority.ADMIN, uuid, "1");
         uuidRepository.save(Authority.ADMIN, uuid, String.valueOf(ADMIN.getId()));
         StandardWebSocketClient client = new StandardWebSocketClient();
 
@@ -155,7 +155,7 @@ public class AdminAgendaWebSocketTest {
     void testSendChatMessageAndVerifyStorage() throws Exception {
         // given
         AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, UPCOMING_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), ADMIN.getId(), null, 0
+                List.of("image1", "image2"), ADMIN.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -177,7 +177,7 @@ public class AdminAgendaWebSocketTest {
     void sendChatToClosedAgenda() throws IOException, InterruptedException {
         // given
         AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, CLOSED_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), ADMIN.getId(), null, 0
+                List.of("image1", "image2"), ADMIN.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -198,7 +198,7 @@ public class AdminAgendaWebSocketTest {
     void sendChatToActiveAgenda() throws Exception {
         // given
         AdminWebsocketMessage payload = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), ADMIN.getId(), null, 0
+                List.of("image1", "image2"), ADMIN.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketConcurrencyTest.java
@@ -56,7 +56,7 @@ public class AgendaWebSocketConcurrencyTest {
     void connectMember() throws ExecutionException, InterruptedException, TimeoutException {
         for (int i = 1; i <= memberCount; i++) {
             final String uuid = UUID.randomUUID().toString();
-            final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(i), Authority.MEMBER, uuid);
+            final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(i), Authority.MEMBER, uuid, "1");
             uuidRepository.save(Authority.MEMBER, uuid, String.valueOf(i));
             StandardWebSocketClient client = new StandardWebSocketClient();
             String url = "ws://localhost:" + port + "/students";
@@ -105,7 +105,7 @@ public class AgendaWebSocketConcurrencyTest {
         StandardWebSocketClient client = new StandardWebSocketClient();
         String url = "ws://localhost:" + port + "/admins";
         final String uuid = UUID.randomUUID().toString();
-        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(1), Authority.ADMIN, uuid);
+        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(1), Authority.ADMIN, uuid, "1");
         uuidRepository.save(Authority.ADMIN, uuid, String.valueOf(1));
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
         headers.add("Sec-WebSocket-Protocol", memberTokens.accessToken());
@@ -128,7 +128,7 @@ public class AgendaWebSocketConcurrencyTest {
                 try {
 
                     MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA_ID, "채팅",
-                            null, memberId, null, 0
+                            null, memberId, null, null, 0
                     );
                     String messageJson = objectMapper.writeValueAsString(payload);
                     sessions.get(memberId).sendMessage(new TextMessage(messageJson));

--- a/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/chat/AgendaWebSocketTest.java
@@ -138,7 +138,7 @@ public class AgendaWebSocketTest {
                 .build());
         MEMBER = memberRepository.save(Member.builder().provider(ProviderType.KAKAO).email("email").loginId("1").university(university).build());
         final String uuid = UUID.randomUUID().toString();
-        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(MEMBER.getId()), Authority.MEMBER, uuid);
+        final MemberTokens memberTokens = jwtProvider.generateLoginToken(String.valueOf(MEMBER.getId()), Authority.MEMBER, uuid, String.valueOf(MEMBER.getUniversity().getId()));
         uuidRepository.save(Authority.MEMBER, uuid, String.valueOf(MEMBER.getId()));
         StandardWebSocketClient client = new StandardWebSocketClient();
 
@@ -171,7 +171,7 @@ public class AgendaWebSocketTest {
     void testSendChatMessageAndVerifyStorage() throws Exception {
         // given
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, UPCOMING_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), MEMBER.getId(), null, 0
+                List.of("image1", "image2"), MEMBER.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -193,7 +193,7 @@ public class AgendaWebSocketTest {
     void sendChatToClosedAgenda() throws IOException, InterruptedException {
         // given
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, CLOSED_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), MEMBER.getId(), null, 0
+                List.of("image1", "image2"), MEMBER.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -214,7 +214,7 @@ public class AgendaWebSocketTest {
     void sendChatToActiveAgenda() throws Exception {
         // given
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA.getId(), "웹소캣 채팅 테스트지롱",
-                List.of("image1", "image2"), MEMBER.getId(), null, 0
+                List.of("image1", "image2"), MEMBER.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -245,7 +245,7 @@ public class AgendaWebSocketTest {
     void enterAgenda() throws Exception {
         // given
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.ENTER, null, ACTIVE_AGENDA.getId(), null,
-                null, MEMBER.getId(), null, 0
+                null, MEMBER.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -276,7 +276,7 @@ public class AgendaWebSocketTest {
         // given
         agendaChatRepository.save(new AgendaChat(null, ACTIVE_AGENDA.getId(), "마지막 채팅", List.of(), true, null, LocalDateTime.now()));
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.LEAVE, null, ACTIVE_AGENDA.getId(), null,
-                null, MEMBER.getId(), null, 0
+                null, MEMBER.getId(), null, null, 0
         );
         String messageJson = objectMapper.writeValueAsString(payload);
         // when
@@ -305,11 +305,11 @@ public class AgendaWebSocketTest {
     void participateAndReceiveChat() throws Exception {
         // given
         MemberWebsocketMessage payload = new MemberWebsocketMessage(RoomType.AGENDA, SocketEventType.PARTICIPATE, null, ACTIVE_AGENDA.getId(), null,
-                null, MEMBER.getId(), null, 0
+                null, MEMBER.getId(), null, null, 0
         );
         String memberWebsocketEvent = objectMapper.writeValueAsString(payload);
         final String uuid = UUID.randomUUID().toString();
-        final MemberTokens adminTokens = jwtProvider.generateLoginToken(String.valueOf(ADMIN.getId()), Authority.ADMIN, uuid);
+        final MemberTokens adminTokens = jwtProvider.generateLoginToken(String.valueOf(ADMIN.getId()), Authority.ADMIN, uuid, String.valueOf(MEMBER.getUniversity().getId()));
         uuidRepository.save(Authority.ADMIN, uuid, String.valueOf(ADMIN.getId()));
 
         StandardWebSocketClient client = new StandardWebSocketClient();
@@ -327,7 +327,7 @@ public class AgendaWebSocketTest {
                 URI.create(url)
         ).get(5, TimeUnit.SECONDS);
         AdminWebsocketMessage adminWebsocketMessage = new AdminWebsocketMessage(RoomType.AGENDA, SocketEventType.CHAT, null, ACTIVE_AGENDA.getId(), "학생회입니다~",
-                List.of("image1", "image2"), ADMIN.getId(), null, 0
+                List.of("image1", "image2"), ADMIN.getId(), null, null, 0
         );
 
         String adminMessage = objectMapper.writeValueAsString(adminWebsocketMessage);

--- a/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
+++ b/backend/src/test/java/com/bungeobbang/backend/opinion/service/MemberOpinionServiceTest.java
@@ -55,6 +55,8 @@ class MemberOpinionServiceTest {
     private OpinionLastReadRepository opinionLastReadRepository;
     @Mock
     private AnsweredOpinionRepository answeredOpinionRepository;
+    @Mock
+    private OpinionRealTimeChatService opinionRealTimeChatService;
 
     @Test
     @DisplayName("1개월 동안의 의견 통계를 계산한다.")


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 말해요 생성 후 실시간으로 학생회가 소켓 이벤트를 수신하지 못하는 문제를 수정하였습니다
- 


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 말해요 구독 최적화
- 학생회는 해당 대학의 말해요를 구독합니다.
- 학생이 말해요 생성 시 해당 대학 말해요 채널에 start이벤트를 전송합니다.


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #393
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
