### PR TITLE
[FIX/FE] 채팅 렌더링 순서, up부터 무조건 렌더링 되도록

### DIFF
--- a/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/admin/pages/agenda/chat/chat-page/index.tsx
@@ -81,7 +81,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
     const handleMessageReceive = useCallback(
       (message: ChatMessage) => {
-        // console.log('message', message);
+        console.log('message', message);
         if (message.roomType === 'AGENDA' && message.agendaId === Number(roomId)) {
           const newChat = {
             type: message.adminId === Number(memberId) ? ChatType.SEND : ChatType.RECEIVE,
@@ -293,7 +293,8 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
     const getMoreDownChatData = async () => {
       try {
-        if (isDownDirection.current) return;
+        if (isDownDirection.current || isUpDirection.current) return;
+
         isDownDirection.current = true;
         const response = await api.get(`/admin/agendas/${roomId}/chat`, {
           params: {
@@ -301,6 +302,12 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
             scroll: 'DOWN',
           },
         });
+
+        if (isUpDirection.current) {
+          //동시 요청 후 렌더링 막음
+          isDownDirection.current = false;
+          return;
+        }
 
         const formattedData = formatChatData(response.data, true);
 
@@ -367,9 +374,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
         isUpDirection.current = false;
 
         return;
-      }
-
-      if (isDownDirection.current === true) {
+      } else if (isDownDirection.current === true) {
         if (isDownOverflow.current === true) {
           restoreScrollTopFromDown();
           isDownOverflow.current = false;
@@ -410,9 +415,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
         }
 
         isLiveSendChatAdded.current = false;
-      }
-
-      if (isLiveReceiveChatAdded.current) {
+      } else if (isLiveReceiveChatAdded.current) {
         if (isLiveReceiveOverflow.current === true) {
           scrollToBottom();
           isLiveReceiveOverflow.current = false;
@@ -494,8 +497,10 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
                     return date ? <TextBadge text={date} /> : null;
                   })()}
+
                   <ReceiverChat
                     chatId={curChatData.chatId}
+                    key={curChatData.chatId}
                     ref={
                       isUpTriggerItem
                         ? (el) => {
@@ -544,6 +549,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
                     return date ? <TextBadge text={date} /> : null;
                   })()}
+
                   <SenderChat
                     key={curChatData.chatId}
                     chatId={curChatData.chatId}

--- a/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/admin/pages/opinion/chatroom/index.tsx
@@ -241,6 +241,7 @@ const OpinionChatPage = () => {
           scroll: 'UP',
         },
       });
+
       const formattedData = formatChatData(response.data, true);
 
       setChatData((prev: ChatData[]) => {
@@ -257,7 +258,8 @@ const OpinionChatPage = () => {
 
   const getMoreDownChatData = async () => {
     try {
-      if (isDownDirection.current) return;
+      if (isDownDirection.current || isUpDirection.current) return;
+
       isDownDirection.current = true;
       const response = await api.get(`/api/opinions/${roomId}/chat`, {
         params: {
@@ -265,6 +267,12 @@ const OpinionChatPage = () => {
           scroll: 'DOWN',
         },
       });
+
+      if (isUpDirection.current) {
+        //동시 요청 후 렌더링 막음
+        isDownDirection.current = false;
+        return;
+      }
 
       const formattedData = formatChatData(response.data, true);
 
@@ -340,9 +348,7 @@ const OpinionChatPage = () => {
 
       isUpDirection.current = false;
       return;
-    }
-
-    if (isDownDirection.current) {
+    } else if (isDownDirection.current) {
       if (isDownOverflow.current === true) {
         restoreScrollTopFromDown();
         isDownOverflow.current = false;
@@ -373,19 +379,16 @@ const OpinionChatPage = () => {
       }
 
       scrollToBottom();
-
       if (MAX_CHAT_DATA_LENGTH < chatData.length) {
         isLiveSendOverflow.current = true;
-
         setHasUpMore(true);
         setChatData((prev) => prev.slice(chatData.length - MAX_CHAT_DATA_LENGTH));
         return;
       }
 
       isLiveSendChatAdded.current = false;
-    }
-
-    if (isLiveReceiveChatAdded.current) {
+      return;
+    } else if (isLiveReceiveChatAdded.current) {
       if (isLiveReceiveOverflow.current === true) {
         scrollToBottom();
         isLiveReceiveOverflow.current = false;
@@ -436,7 +439,7 @@ const OpinionChatPage = () => {
                 })()}
                 <ReceiverChat
                   chatId={curChatData.chatId}
-                  key={index}
+                  key={curChatData.chatId}
                   ref={
                     isUpTriggerItem
                       ? (el) => {
@@ -482,7 +485,7 @@ const OpinionChatPage = () => {
                 })()}
                 <SenderChat
                   chatId={curChatData.chatId}
-                  key={index}
+                  key={curChatData.chatId}
                   ref={
                     isUpTriggerItem
                       ? (el) => {

--- a/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
+++ b/frontend/src/domains/student/pages/agenda/chat/chat-page/index.tsx
@@ -262,6 +262,8 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
     const getMoreUpChatData = async () => {
       try {
+        if (isUpDirection.current) return;
+
         isUpDirection.current = true;
         const response = await api.get(`/student/agendas/${roomId}/chat`, {
           params: {
@@ -285,6 +287,8 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
     const getMoreDownChatData = async () => {
       try {
+        if (isDownDirection.current || isUpDirection.current) return;
+
         isDownDirection.current = true;
         const response = await api.get(`/student/agendas/${roomId}/chat`, {
           params: {
@@ -292,6 +296,12 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
             scroll: 'DOWN',
           },
         });
+
+        if (isUpDirection.current) {
+          //동시 요청 후 렌더링 막음
+          isDownDirection.current = false;
+          return;
+        }
 
         const formattedData = formatChatData(response.data, false);
 
@@ -357,9 +367,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
 
         isUpDirection.current = false;
         return;
-      }
-
-      if (isDownDirection.current) {
+      } else if (isDownDirection.current) {
         if (isDownOverflow.current === true) {
           restoreScrollTopFromDown();
           isDownOverflow.current = false;
@@ -399,9 +407,7 @@ const ChatPage = forwardRef<HTMLDivElement, ChatPageProps>(
         }
 
         isLiveSendChatAdded.current = false;
-      }
-
-      if (isLiveReceiveChatAdded.current) {
+      } else if (isLiveReceiveChatAdded.current) {
         if (isLiveReceiveOverflow.current === true) {
           scrollToBottom();
           isLiveReceiveOverflow.current = false;

--- a/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
+++ b/frontend/src/domains/student/pages/opinion/chatroom/index.tsx
@@ -294,6 +294,7 @@ const OpinionChatPage = () => {
 
   const getMoreUpChatData = async () => {
     try {
+      if (isUpDirection.current) return;
       isUpDirection.current = true;
       const response = await api.get(`/api/opinions/${roomId}/chat`, {
         params: {
@@ -317,6 +318,8 @@ const OpinionChatPage = () => {
 
   const getMoreDownChatData = async () => {
     try {
+      if (isDownDirection.current || isUpDirection.current) return;
+
       isDownDirection.current = true;
       const response = await api.get(`/api/opinions/${roomId}/chat`, {
         params: {
@@ -324,6 +327,12 @@ const OpinionChatPage = () => {
           scroll: 'DOWN',
         },
       });
+
+      if (isUpDirection.current) {
+        //동시 요청 후 렌더링 막음
+        isDownDirection.current = false;
+        return;
+      }
 
       const formattedData = formatChatData(response.data, false);
 
@@ -389,9 +398,7 @@ const OpinionChatPage = () => {
 
       isUpDirection.current = false;
       return;
-    }
-
-    if (isDownDirection.current) {
+    } else if (isDownDirection.current) {
       if (isDownOverflow.current === true) {
         restoreScrollTopFromDown();
         isDownOverflow.current = false;
@@ -432,9 +439,7 @@ const OpinionChatPage = () => {
       }
 
       isLiveSendChatAdded.current = false;
-    }
-
-    if (isLiveReceiveChatAdded.current) {
+    } else if (isLiveReceiveChatAdded.current) {
       if (isLiveReceiveOverflow.current === true) {
         scrollToBottom();
         isLiveReceiveOverflow.current = false;

--- a/frontend/src/hooks/useInfiniteScroll.tsx
+++ b/frontend/src/hooks/useInfiniteScroll.tsx
@@ -53,6 +53,7 @@ const useInfiniteScroll = ({
       upObserver.current = new IntersectionObserver(
         (entries) => {
           const [entry] = entries;
+          console.log('up item!');
           if (entry.isIntersecting && hasUpMore.current && !!fetchUpMore) {
             fetchUpMore();
           }
@@ -70,6 +71,7 @@ const useInfiniteScroll = ({
       downObserver.current = new IntersectionObserver(
         (entries) => {
           const [entry] = entries;
+          console.log('down item!');
 
           if (entry.isIntersecting && hasDownMore.current && !!fetchDownMore) {
             fetchDownMore();

--- a/frontend/src/utils/chat/formatChatData.ts
+++ b/frontend/src/utils/chat/formatChatData.ts
@@ -33,9 +33,7 @@ export const formatChatData = (
   adminName?: string,
 ): ChatData[] => {
   // 날짜순으로 정렬
-  const sortedData = [...serverData].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-  );
+  const sortedData = [...serverData].sort((a, b) => a.chatId.localeCompare(b.chatId));
 
   // 기본 채팅 데이터 포맷팅
   const formattedChats: ChatData[] = sortedData.map((item) => {


### PR DESCRIPTION
## 📌 작업 내용
<!-- 
### 작업 내용
- 이 Pull Request에서 구현한 내용에 대한 요약을 작성합니다.
- 어떤 문제를 해결하거나, 어떤 기능을 추가했는지 간략하게 설명하세요.
-->
- 채팅 동일 시간 데이터 있으면 정렬 시 순서 뒤바뀌는 문제 해결 -> chatId로 정렬하도록
- 마지막 채팅이 2개인 경우, up down이 동시에 추가 요청이 되는데 이 과정에서 up이 먼저 렌더링 되냐, down이 먼저 렌더링 되냐에 따라서 스크롤 위치가 간헐적으로 이상해짐 -> 무조건 한 번에 하나씩 요청이 되는데 up이 먼저 요청이 되도록 수정
- down은 up이 요청중이면 요청을 하지 않고 down observer가 먼저 호출되어서 서버에 요청이 갔어도 그 사이에 up 요청이 갔으면 데이터 추가 하지 않음


---

## 📂 주요 변경사항
<!-- 
### 주요 변경사항
1. 파일 또는 코드의 주요 수정 내용을 간단히 작성합니다.
2. 새로운 파일 추가/삭제나 주요 로직 변경을 기술합니다.
예:
- [ ] UserService 클래스 리팩토링
- [ ] API 응답 속도 개선 로직 추가
-->
- 
- 


---

## 📑 세부 변경사항
<!-- 
### 세부 변경사항
- 주요 변경사항 이외의 세부적인 수정 내용을 명확히 작성합니다.
- 예:
  - UserService 클래스에 로그인 검증 추가
  - /api/v1/users 엔드포인트에 JWT 인증 로직 추가
-->
- 
- 


---

## 🔗 관련 이슈
<!-- 
### 관련 이슈
- PR과 연관된 이슈를 명시합니다.
- "Closes #이슈번호" 형식으로 작성하면 PR 병합 시 이슈가 자동으로 닫힙니다.
예:
- Closes #123
- 관련 링크: [JIRA, Trello 등 링크]
-->
- Closes #
- 관련 링크: 


---

## ✅ 검토 요청사항
<!-- 
### 검토 요청사항
- 리뷰어에게 요청하고 싶은 사항이나 확인해야 할 작업을 작성합니다.
예:
- [ ] 테스트 코드 검토 요청
- [ ] API 문서 검토 요청
-->
- [ ] 
- [ ] 
